### PR TITLE
ci: verify kconfig release archives before tagging

### DIFF
--- a/.github/workflows/build_kconfig_prebuilts.sh
+++ b/.github/workflows/build_kconfig_prebuilts.sh
@@ -4,18 +4,20 @@ set -euo pipefail
 export LANG=C
 export LC_ALL=C
 
-if [[ -z "${BUILDBUDDY_API_KEY:-}" ]]; then
-  echo "BUILDBUDDY_API_KEY GitHub secret is required for kconfig prebuilt builds." >&2
-  exit 1
+BAZEL_STARTUP_ARGS=()
+BAZEL_ARGS=("--lockfile_mode=error")
+if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
+  BAZEL_ARGS+=(
+    "--remote_cache=grpcs://remote.buildbuddy.io"
+    "--remote_executor=grpcs://remote.buildbuddy.io"
+    "--remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
+  )
+else
+  BAZEL_STARTUP_ARGS=("--ignore_all_rc_files")
 fi
 
-BAZEL_ARGS=(
-  "--remote_cache=grpcs://remote.buildbuddy.io"
-  "--remote_executor=grpcs://remote.buildbuddy.io"
-  "--remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}"
-)
-
-bazel build "${BAZEL_ARGS[@]}" //internal/cmd/kconfig/prebuilts:kconfig_prebuilts
+bazel "${BAZEL_STARTUP_ARGS[@]}" build "${BAZEL_ARGS[@]}" \
+  //internal/cmd/kconfig/prebuilts:kconfig_prebuilts
 
 rm -rf dist
 mkdir -p dist
@@ -24,7 +26,10 @@ copy_out() {
   local label="$1"
   local src
 
-  src="$(bazel cquery "${BAZEL_ARGS[@]}" --output=files "${label}")"
+  src="$(
+    bazel "${BAZEL_STARTUP_ARGS[@]}" cquery "${BAZEL_ARGS[@]}" \
+      --output=files "${label}"
+  )"
   cp "${src}" "dist/$(basename "${src}")"
 }
 

--- a/.github/workflows/kconfig-prebuilts.yml
+++ b/.github/workflows/kconfig-prebuilts.yml
@@ -1,7 +1,10 @@
 name: kconfig prebuilts
 
 on:
+  pull_request:
   push:
+    branches:
+      - fionera/init
     tags:
       - "kconfig-v*"
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 .bazelrc.user
 bazel-*
+/dist/

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,9 +26,24 @@ use_repo(linux_bzl_libelf, "libelf")
 tar_toolchains = use_extension("@tar.bzl//tar:extensions.bzl", "toolchains", dev_dependency = True)
 use_repo(tar_toolchains, "bsd_tar_toolchains")
 
+llvm_toolchains = use_extension("@llvm//extensions:toolchain.bzl", "toolchain")
+llvm_toolchains.target(
+    arch = "x86_64",
+    os = "linux",
+)
+llvm_toolchains.target(
+    arch = "aarch64",
+    os = "linux",
+)
+use_repo(llvm_toolchains, "llvm_toolchains")
+
 register_toolchains(
     "@bsd_tar_toolchains//:all",
-    "@llvm//toolchain:all",
+    dev_dependency = True,
+)
+
+register_toolchains(
+    "@llvm_toolchains//:all",
     dev_dependency = True,
 )
 

--- a/internal/cmd/kconfig/BUILD.bazel
+++ b/internal/cmd/kconfig/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
 go_binary(
     name = "kconfig",
     embed = [":kconfig_lib"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/internal/cmd/kconfig_parse/BUILD.bazel
+++ b/internal/cmd/kconfig_parse/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
 go_binary(
     name = "kconfig_parse",
     embed = [":kconfig_parse_lib"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
## Summary

- run the complete Kconfig prebuilt release build for every pull request and push to `fionera/init`, while keeping publication conditional on `kconfig-v*` tags
- restrict registered Hermetic LLVM C++ toolchains to Linux targets so pure-Go Darwin cross-builds cannot resolve the obsolete macOS SDK repository
- mark both release binaries explicitly pure and make BuildBuddy optional so fork pull requests execute the same release script without secrets
- require an unchanged module lock and ignore generated `dist/` payloads

## Root cause

rules_go declares an optional C++ toolchain even for pure Go targets. Registering `@llvm//toolchain:all` gave the Darwin platform transitions a matching macOS C++ toolchain, whose sysroot fetched Hermetic LLVM 0.7.1's now-forbidden Apple SDK URL. The v0.0.12 tag workflow therefore failed during analysis before producing any archive.

PR #8 had no normal check for the aggregate release target. The same Darwin failure had been observed locally but was left as a release-time gate; this change moves the exact release build into presubmit CI.

## Validation

- `.github/workflows/build_kconfig_prebuilts.sh` completed without a BuildBuddy key and built/validated all six `.tar.zst` archives, including Darwin amd64 and arm64
- the same script completed with the shared BuildBuddy configuration, exercising the tag workflow path
- `bazel test //internal/cmd/kconfig:kconfig_test //internal/cmd/kconfig_parse:kconfig_parse_test //internal:kconfig_tool_filename_test`
- `go test ./internal/cmd/kconfig ./internal/cmd/kconfig_parse`
- `bazel mod tidy`, Buildifier, `actionlint`, `bash -n`, and `git diff --check`

The failed `kconfig-v0.0.12` tag was deleted and produced no release. Recreate it only after this PR's full archive check passes on the merged commit.