### PR TITLE
ci: run workflows on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - fionera/init
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/kconfig-prebuilts.yml
+++ b/.github/workflows/kconfig-prebuilts.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - fionera/init
+      - main
     tags:
       - "kconfig-v*"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- run the primary CI workflow for pushes to the new `main` default branch
- run kconfig prebuilt verification for pushes to `main` while preserving the existing tag release trigger

## Why

The repository default branch moved from `fionera/init` to `main`, but both push filters still referenced the old branch. As a result, merged changes on `main` would not trigger either workflow.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- repository-wide search confirms no remaining `fionera/init` automation references