### PR TITLE
ci: exercise kernel builds from macOS and Windows

### DIFF
--- a/.github/workflows/host-platforms.yml
+++ b/.github/workflows/host-platforms.yml
@@ -1,0 +1,91 @@
+name: Host platform builds
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: host-platforms-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  examples:
+    name: Standalone kernels (${{ matrix.host }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: macOS
+            runner: macos-latest
+          - host: Windows
+            runner: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Configure Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ runner.os }}
+          module-root: examples
+          repository-cache: |
+            - examples/.bazelversion
+            - examples/MODULE.bazel
+            - examples/MODULE.bazel.lock
+          cache-save: ${{ github.event_name != 'pull_request' }}
+
+      - name: Build Linux kernels
+        working-directory: examples
+        env:
+          BAZEL_BEP: ../.ci-artifacts/${{ runner.os }}.bep.json
+          BAZEL_LOG: ../.ci-artifacts/${{ runner.os }}.log
+          BAZEL_PROFILE: ../.ci-artifacts/${{ runner.os }}.profile.gz
+        run: |
+          set -euo pipefail
+          mkdir -p ../.ci-artifacts
+          bazel --bazelrc="${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc" \
+            build \
+            //:x86_64_kernel \
+            //:x86_64_debug_kernel \
+            //:x86_64_lz4_kernel \
+            --config=path-mapping \
+            --build_event_json_file="${BAZEL_BEP}" \
+            --profile="${BAZEL_PROFILE}" \
+            2>&1 | tee "${BAZEL_LOG}"
+
+      - name: Report cache efficiency
+        if: ${{ !cancelled() }}
+        env:
+          BAZEL_BEP: .ci-artifacts/${{ runner.os }}.bep.json
+          BAZEL_LOG: .ci-artifacts/${{ runner.os }}.log
+          BAZEL_PROFILE: .ci-artifacts/${{ runner.os }}.profile.gz
+        run: |
+          .github/workflows/bazel_cache_report.sh \
+            "Standalone kernels (${{ matrix.host }})" \
+            "${BAZEL_PROFILE}" \
+            "${BAZEL_BEP}" \
+            "${BAZEL_LOG}"
+
+      - name: Upload Bazel profile
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: bazel-profile-host-${{ runner.os }}
+          path: |
+            .ci-artifacts/${{ runner.os }}.profile.gz
+            .ci-artifacts/${{ runner.os }}.bep.json
+            .ci-artifacts/${{ runner.os }}.log
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
## Summary

- add a dedicated GitHub-hosted `macos-latest` / `windows-latest` workflow
- build the x86_64 base, debug, and LZ4 kernels in one Bazel invocation per host
- retain the declared hermetic Linux execution platform while exercising host-native repository setup and `kconfig_parse`
- report cache efficiency and retain the BEP JSON, compressed profile, and complete build log for both hosts

## Why

The normal CI only runs on Ubuntu, so host-specific source extraction and repository-rule behavior can regress without being observed. A full build from each non-Linux host covers more than module resolution: the host downloads and materializes Linux sources, runs the released native graph generator, analyzes the generated repository, and requests the resulting Linux compile/link actions.

The overlays stay in one invocation so the job also exercises action deduplication and shared caching. Diagnostics are collected under workspace-relative `.ci-artifacts` paths so Git Bash and native Windows Bazel never have to exchange `runner.temp` drive-letter paths.

## Scope and limitations

This deliberately does not run QEMU on macOS or Windows. Kernel compilation remains on linux.bzl's hermetic Linux execution platform through remote execution; the workflow validates macOS and Windows as Bazel client/repository hosts, not as kernel execution hosts.

This depends on the case-insensitive source-package fix in #14. The initial macOS and Windows runs both reached that existing failure; the host matrix must be rerun after #14 lands on `main`.

## Validation

- `actionlint .github/workflows/host-platforms.yml`
- `git diff --check`
- local CI-config probe resolved both image repositories, completed the aarch64 kernel, and entered x86_64 overlay generation; the probe was stopped before exhausting the shared workspace disk, and the committed host jobs use only the three x86_64 targets
- GitHub scheduled both `macos-latest` and `windows-latest`
- both hosts reached the expected pre-#14 `Build` package-marker collision
- Windows successfully used Git Bash paths, generated the cache report, and uploaded the BEP, compressed profile, and log artifact: https://github.com/hermeticbuild/linux.bzl/actions/runs/30311562436/artifacts/8671447992