### PR TITLE
linux: normalize source package markers

### DIFF
--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -374,6 +374,17 @@ build_test(
     ],
 )
 
+build_test(
+    name = "linux_source_root_package_build_test",
+    targets = [
+        "@e2e_linux_6_18_39//:tools/bpf/resolve_btfids/main.c",
+        "@e2e_linux_6_18_39//:tools/lib/subcmd/Build.linux-bzl",
+        "@e2e_linux_6_18_39//:tools/lib/subcmd/subcmd-config.c",
+        "@e2e_linux_6_18_39//:tools/objtool/arch/x86/decode.c",
+        "@e2e_linux_6_18_39//:tools/objtool/objtool.c",
+    ],
+)
+
 test_suite(
     name = "kernel_outputs_build_test",
     tests = [

--- a/internal/linux_source_repository.bzl
+++ b/internal/linux_source_repository.bzl
@@ -26,6 +26,60 @@ _KERNEL_RELEASES = {
     ),
 }
 
+# Case-insensitive filesystems treat Linux's tools/**/Build make fragments as
+# Bazel package markers. Relocate them on every host for identical repositories.
+_TOOLS_BUILD_FILE = "Build"
+_TOOLS_BUILD_FILE_RELOCATED = "Build.linux-bzl"
+_TOOLS_MAX_DEPTH = 64
+
+def _relocate_tools_build_files(rctx, tools):
+    relocated = 0
+    directories = [tools]
+    for _ in range(_TOOLS_MAX_DEPTH):
+        if not directories:
+            break
+        next_directories = []
+        for directory in directories:
+            for entry in directory.readdir(watch = "no"):
+                if entry.is_dir:
+                    next_directories.append(entry)
+                elif entry.basename == _TOOLS_BUILD_FILE:
+                    rctx.rename(
+                        entry,
+                        entry.dirname.get_child(_TOOLS_BUILD_FILE_RELOCATED),
+                    )
+                    relocated += 1
+        directories = next_directories
+    if directories:
+        fail("Linux tools directory exceeds the supported traversal depth")
+    return relocated
+
+def _normalize_tools_build_files(rctx):
+    tools = rctx.path("tools")
+    if not tools.exists:
+        return
+
+    relocated = _relocate_tools_build_files(rctx, tools)
+    if relocated == 0:
+        return
+
+    makefile = rctx.path("tools/build/Makefile.build")
+    if not makefile.exists:
+        fail("Linux tools contain Build files but no tools/build/Makefile.build")
+
+    build_file_assignment = "build-file := $(dir)/Build\n"
+    relocated_assignment = "build-file := $(dir)/%s\n" % _TOOLS_BUILD_FILE_RELOCATED
+    content = rctx.read(makefile)
+    if build_file_assignment not in content:
+        fail(
+            "Linux tools/build/Makefile.build does not contain the expected Build assignment",
+        )
+    rctx.file(
+        makefile,
+        content.replace(build_file_assignment, relocated_assignment),
+        executable = False,
+    )
+
 def _linux_source_repository_impl(rctx):
     catalog = _KERNEL_RELEASES.get(rctx.attr.version)
     has_urls = len(rctx.attr.urls) != 0
@@ -60,6 +114,7 @@ def _linux_source_repository_impl(rctx):
     )
     for patch in rctx.attr.patches:
         rctx.patch(patch, strip = rctx.attr.patch_strip)
+    _normalize_tools_build_files(rctx)
 
     makefile = rctx.path("Makefile")
     kconfig = rctx.path("Kconfig")


### PR DESCRIPTION
## Summary

- relocate upstream Linux `tools/**/Build` make fragments to `Build.linux-bzl` in `linux_source_repository`
- update `tools/build/Makefile.build` to consume the relocated fragments
- apply the transform on every host so external repository contents and cache keys stay host-independent
- add a focused source-root package regression test for the `resolve_btfids`, `subcmd`, and `objtool` inputs

## Root cause

Linux uses capitalized `Build` files as GNU Make fragments under `tools/`. On case-insensitive filesystems, Bazel treats those paths as legacy `BUILD` package markers. That silently creates nested packages and prunes required host-tool sources from the root repository's exported file set, causing macOS analysis failures such as the missing `tools/lib/subcmd/subcmd-config.c` target. Windows has the same filesystem collision risk.

The repository rule now performs a bounded traversal using Bazel's native repository APIs after user patches are applied. For Linux 6.18.39 this deterministically relocates all 79 fragments, leaves only the generated root `BUILD.bazel` as a Bazel package marker, and preserves the kernel tools build semantics.

## Validation

- `bazel run //:buildifier`
- `bazel test //:linux_source_root_package_build_test --config=remote` ([BuildBuddy](https://app.buildbuddy.io/invocation/84cd900f-311a-402b-9cfd-85456aa95545))
- Aya x86_64 and aarch64 VM targets in one invocation with `--override_module=linux.bzl=/workspace/linux.bzl-macos-source` ([BuildBuddy](https://app.buildbuddy.io/invocation/dc5ddff5-bccc-4cfb-8509-1eaf5eaf5509))