### PR TITLE
Use kconfig v0.0.13

### DIFF
--- a/internal/config_validation.bzl
+++ b/internal/config_validation.bzl
@@ -26,12 +26,6 @@ def validate_config_features(config, description):
     ]:
         if config.get(symbol, "n") in ["y", "m"]:
             fail("%s enables %s, whose module metadata instrumentation is not modeled" % (description, symbol))
-    if config.get("CONFIG_KCSAN", "n") in ["y", "m"]:
-        fail(
-            "%s enables CONFIG_KCSAN, which requires the next kconfig generator release " %
-            description +
-            "to emit per-object instrumentation",
-        )
 
     for symbol in [
         "CONFIG_MODULE_SIG",

--- a/internal/kconfig_tool_releases.bzl
+++ b/internal/kconfig_tool_releases.bzl
@@ -5,7 +5,7 @@ Each archive must extract the requested host executables at its root.
 
 visibility("//...")
 
-KCONFIG_TOOL_VERSION = "v0.0.12"
+KCONFIG_TOOL_VERSION = "v0.0.13"
 
 _RELEASE_BASE_URL = "https://github.com/hermeticbuild/linux.bzl/releases/download/kconfig-{version}".format(
     version = KCONFIG_TOOL_VERSION,
@@ -13,27 +13,27 @@ _RELEASE_BASE_URL = "https://github.com/hermeticbuild/linux.bzl/releases/downloa
 
 KCONFIG_TOOL_RELEASES = {
     "darwin_amd64": struct(
-        integrity = "sha256-g8vKOukDOy7e7ED6LnCygFlAgvFfCOVGXae76PvVjOM=",
+        integrity = "sha256-VbTy013fU6sDaSG7so6GlfhxJsh1nBUhgs4CoG6oRs4=",
         urls = ["{}/kconfig-darwin-amd64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "darwin_arm64": struct(
-        integrity = "sha256-FTUowStHo50sOsJH7XO4S7O9cfJ3xLMi8Co5OwtOd8U=",
+        integrity = "sha256-SPyePCQ4eRSw9tC6wFgZwsoUc9gqOg4h8V117JbnhFw=",
         urls = ["{}/kconfig-darwin-arm64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "linux_amd64": struct(
-        integrity = "sha256-LsXQpfJDbOEv920zoTSTzz09hBrRPW71zTvW0J8618k=",
+        integrity = "sha256-gVgzWUoPMTm8bnHBZED3LNQcndMU7+4VTQb3Lp0AQtE=",
         urls = ["{}/kconfig-linux-amd64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "linux_arm64": struct(
-        integrity = "sha256-1Ui1faoEJPbKGtJuVbcz8hmLIXHzMD8U9mGHnYYihBk=",
+        integrity = "sha256-RzFvFB/l2F+sg5DYNZm+3l7krPl7eIi9c0Rb9oBx9o8=",
         urls = ["{}/kconfig-linux-arm64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "windows_amd64": struct(
-        integrity = "sha256-Yry+HxjzixIgi8U/uULoxTAFQEzzoQsL0MV5Xga7va4=",
+        integrity = "sha256-N7ncGu2gSMkl9xs4Rm2XvtCsjrZotOysvmm91nRb87s=",
         urls = ["{}/kconfig-windows-amd64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "windows_arm64": struct(
-        integrity = "sha256-2eqgng6HGDVyh/MbMkEDyD5yfNA3rasKyzXxhhYvFis=",
+        integrity = "sha256-+Mm6T+T8LOFa9tBHlM24BiIJQdwqLrjIbKrOkGfRmzw=",
         urls = ["{}/kconfig-windows-arm64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
 }

--- a/internal/tests/config_validation_test.bzl
+++ b/internal/tests/config_validation_test.bzl
@@ -1,6 +1,6 @@
 """Analysis tests for supported Linux config validation."""
 
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("//internal:config_validation.bzl", "validate_config_features")
 
 visibility("private")
@@ -29,6 +29,16 @@ config_validation_failure_test = analysistest.make(
     expect_failure = True,
 )
 
+def _config_validation_kcsan_test_impl(ctx):
+    env = unittest.begin(ctx)
+    validate_config_features(
+        {"CONFIG_KCSAN": "y"},
+        str(ctx.label),
+    )
+    return unittest.end(env)
+
+config_validation_kcsan_test = unittest.make(_config_validation_kcsan_test_impl)
+
 def config_validation_test_suite(name):
     cases = {
         "cfi_modules": (
@@ -46,10 +56,6 @@ def config_validation_test_suite(name):
         "gendwarfksyms": (
             {"CONFIG_GENDWARFKSYMS": "y"},
             "module versioning",
-        ),
-        "kcsan_modules": (
-            {"CONFIG_KCSAN": "y"},
-            "requires the next kconfig generator release",
         ),
         "modversions": (
             {"CONFIG_MODVERSIONS": "y"},
@@ -83,6 +89,10 @@ def config_validation_test_suite(name):
             target_under_test = ":" + fixture,
         )
         tests.append(":" + test)
+
+    kcsan_test = name + "_kcsan_test"
+    config_validation_kcsan_test(name = kcsan_test)
+    tests.append(":" + kcsan_test)
 
     native.test_suite(
         name = name,


### PR DESCRIPTION
## Summary

- consume the published kconfig v0.0.13 binaries and integrity hashes on all six supported host platforms
- remove the temporary CONFIG_KCSAN validation rejection now that the released generator models sanitizer instrumentation
- replace the KCSAN failure expectation with a positive validation test

This is the release-integration follow-up to #11.

Release: https://github.com/hermeticbuild/linux.bzl/releases/tag/kconfig-v0.0.13

## Validation

- `go test ./internal/kconfig ./internal/cmd/kconfig ./internal/cmd/kconfig_parse`
- `bazel test //internal/tests:config_validation_tests //internal/tests:linux_module_test //internal/tests:sanitizer_actions_test //:buildifier_test //:gazelle_test --test_output=errors`
- `bazel build //:x86_64_debug_kernel --config=path-mapping --config=remote` from `examples/` (3,151 actions; generated repository reports `tool_version: v0.0.13`)
- verified all six published release archive checksums and SRI values