### PR TITLE
tools: report unique producer fanout

### DIFF
--- a/internal/cmd/linuxobjectinputreport/main.go
+++ b/internal/cmd/linuxobjectinputreport/main.go
@@ -28,9 +28,12 @@ type artifact struct {
 }
 
 type action struct {
-	TargetID       int    `json:"targetId"`
-	Mnemonic       string `json:"mnemonic"`
-	InputDepSetIDs []int  `json:"inputDepSetIds"`
+	TargetID        int    `json:"targetId"`
+	ConfigurationID int    `json:"configurationId"`
+	Mnemonic        string `json:"mnemonic"`
+	InputDepSetIDs  []int  `json:"inputDepSetIds"`
+	OutputIDs       []int  `json:"outputIds"`
+	PrimaryOutputID int    `json:"primaryOutputId"`
 }
 
 type target struct {
@@ -67,6 +70,22 @@ type actionSummary struct {
 	count int
 }
 
+type producerID int
+
+type producer struct {
+	actionIndex       int
+	mnemonic          string
+	target            string
+	configurationID   int
+	primaryOutputPath string
+	outputCount       int
+}
+
+type producerUse struct {
+	producer  producer
+	consumers int
+}
+
 func main() {
 	opts := reportOptions{}
 	flag.StringVar(&opts.inputPath, "input", "", "Path to Bazel aquery JSON proto. Reads stdin when empty or -.")
@@ -99,7 +118,10 @@ func run(w io.Writer, opts reportOptions) error {
 	if err := json.Unmarshal(data, &aq); err != nil {
 		return fmt.Errorf("parse aquery JSON: %w", err)
 	}
-	model := newModel(&aq)
+	model, err := newModel(&aq)
+	if err != nil {
+		return fmt.Errorf("build aquery model: %w", err)
+	}
 	return writeReport(w, model, opts)
 }
 
@@ -119,18 +141,21 @@ func readInput(path string) ([]byte, error) {
 }
 
 type model struct {
-	aq           *aqueryOutput
-	artifactPath map[int]string
-	depSets      map[int]depSet
-	targetLabels map[int]string
+	aq               *aqueryOutput
+	artifactPath     map[int]string
+	depSets          map[int]depSet
+	targetLabels     map[int]string
+	artifactProducer map[int]producerID
+	producers        []producer
 }
 
-func newModel(aq *aqueryOutput) *model {
+func newModel(aq *aqueryOutput) (*model, error) {
 	m := &model{
-		aq:           aq,
-		artifactPath: map[int]string{},
-		depSets:      map[int]depSet{},
-		targetLabels: map[int]string{},
+		aq:               aq,
+		artifactPath:     map[int]string{},
+		depSets:          map[int]depSet{},
+		targetLabels:     map[int]string{},
+		artifactProducer: map[int]producerID{},
 	}
 	fragments := map[int]pathFragment{}
 	for _, fragment := range aq.PathFragments {
@@ -145,7 +170,76 @@ func newModel(aq *aqueryOutput) *model {
 	for _, target := range aq.Targets {
 		m.targetLabels[target.ID] = target.Label
 	}
-	return m
+	for actionIndex, action := range aq.Actions {
+		outputIDs := uniqueInts(action.OutputIDs)
+		if len(outputIDs) == 0 {
+			continue
+		}
+		for _, outputID := range outputIDs {
+			if existingID, ok := m.artifactProducer[outputID]; ok {
+				existing := m.producers[existingID]
+				return nil, fmt.Errorf(
+					"artifact %d is output by multiple actions (%d and %d)",
+					outputID,
+					existing.actionIndex,
+					actionIndex,
+				)
+			}
+		}
+		id := producerID(len(m.producers))
+		p := producer{
+			actionIndex:       actionIndex,
+			mnemonic:          action.Mnemonic,
+			target:            m.targetLabels[action.TargetID],
+			configurationID:   action.ConfigurationID,
+			primaryOutputPath: primaryOutputPath(action.PrimaryOutputID, outputIDs, m.artifactPath),
+			outputCount:       len(outputIDs),
+		}
+		m.producers = append(m.producers, p)
+		for _, outputID := range outputIDs {
+			m.artifactProducer[outputID] = id
+		}
+	}
+	return m, nil
+}
+
+func uniqueInts(values []int) []int {
+	out := make([]int, 0, len(values))
+	seen := make(map[int]bool, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func primaryOutputPath(primaryOutputID int, outputIDs []int, artifactPaths map[int]string) string {
+	outputSet := make(map[int]bool, len(outputIDs))
+	for _, outputID := range outputIDs {
+		outputSet[outputID] = true
+	}
+	if outputSet[primaryOutputID] {
+		return artifactDisplay(primaryOutputID, artifactPaths)
+	}
+	candidates := make([]string, 0, len(outputIDs))
+	for _, outputID := range outputIDs {
+		candidates = append(candidates, artifactDisplay(outputID, artifactPaths))
+	}
+	sort.Strings(candidates)
+	if len(candidates) == 0 {
+		return ""
+	}
+	return candidates[0]
+}
+
+func artifactDisplay(artifactID int, artifactPaths map[int]string) string {
+	if path := artifactPaths[artifactID]; path != "" {
+		return path
+	}
+	return fmt.Sprintf("artifact#%d", artifactID)
 }
 
 func resolvePathFragment(fragments map[int]pathFragment, id int) string {
@@ -181,8 +275,10 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 	actionSummaries := make([]actionSummary, 0, len(actions))
 	inputCounts := make([]int, 0, len(actions))
 	inputUses := map[int]*inputUse{}
+	producerConsumerCounts := make([]int, len(m.producers))
+	producerSeenGeneration := make([]int, len(m.producers))
 
-	for _, action := range actions {
+	for actionIndex, action := range actions {
 		inputs := m.actionInputs(action)
 		for artifactID := range inputs {
 			path := m.artifactPath[artifactID]
@@ -192,6 +288,12 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 				inputUses[artifactID] = use
 			}
 			use.count++
+			if id, ok := m.artifactProducer[artifactID]; ok {
+				if producerSeenGeneration[id] != actionIndex+1 {
+					producerSeenGeneration[id] = actionIndex + 1
+					producerConsumerCounts[id]++
+				}
+			}
 		}
 		inputCounts = append(inputCounts, len(inputs))
 		actionSummaries = append(actionSummaries, actionSummary{
@@ -216,6 +318,20 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 	writeTopInputs(w, "high-fanout non-header source inputs", topInputs(inputUses, func(use *inputUse) bool {
 		return use.count >= threshold && isSourceLikeNonHeader(use.path)
 	}), opts.top, len(actions))
+	resolvedProducerInputs := 0
+	for artifactID := range inputUses {
+		if _, ok := m.artifactProducer[artifactID]; ok {
+			resolvedProducerInputs++
+		}
+	}
+	writeProducerUses(
+		w,
+		opts.mnemonic,
+		topProducerUses(m.producers, producerConsumerCounts),
+		opts.top,
+		resolvedProducerInputs,
+		len(inputUses),
+	)
 	writeActionSummaries(w, "largest actions by input count", topActionSummaries(actionSummaries), opts.top)
 	return nil
 }
@@ -280,6 +396,38 @@ func topActionSummaries(actions []actionSummary) []actionSummary {
 	return out
 }
 
+func topProducerUses(producers []producer, consumerCounts []int) []producerUse {
+	out := make([]producerUse, 0, len(producers))
+	for i, producer := range producers {
+		if consumerCounts[i] == 0 {
+			continue
+		}
+		out = append(out, producerUse{
+			producer:  producer,
+			consumers: consumerCounts[i],
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].consumers != out[j].consumers {
+			return out[i].consumers > out[j].consumers
+		}
+		if out[i].producer.mnemonic != out[j].producer.mnemonic {
+			return out[i].producer.mnemonic < out[j].producer.mnemonic
+		}
+		if out[i].producer.target != out[j].producer.target {
+			return out[i].producer.target < out[j].producer.target
+		}
+		if out[i].producer.primaryOutputPath != out[j].producer.primaryOutputPath {
+			return out[i].producer.primaryOutputPath < out[j].producer.primaryOutputPath
+		}
+		if out[i].producer.configurationID != out[j].producer.configurationID {
+			return out[i].producer.configurationID < out[j].producer.configurationID
+		}
+		return out[i].producer.actionIndex < out[j].producer.actionIndex
+	})
+	return out
+}
+
 func writeTopInputs(w io.Writer, title string, inputs []inputUse, limit int, actionCount int) {
 	fmt.Fprintf(w, "%s:\n", title)
 	if len(inputs) == 0 {
@@ -294,6 +442,52 @@ func writeTopInputs(w io.Writer, title string, inputs []inputUse, limit int, act
 		fmt.Fprintf(w, "  %5d %6.1f%%  %s\n", input.count, pct, input.path)
 	}
 	fmt.Fprintf(w, "\n")
+}
+
+func writeProducerUses(
+	w io.Writer,
+	consumerMnemonic string,
+	producers []producerUse,
+	limit int,
+	resolvedInputCount int,
+	inputCount int,
+) {
+	fmt.Fprintf(
+		w,
+		"producer fanout (unique %s consumer actions; producers present in aquery):\n",
+		consumerMnemonic,
+	)
+	fmt.Fprintf(w, "  producer-resolved input artifacts: %d / %d unique inputs\n", resolvedInputCount, inputCount)
+	if len(producers) == 0 {
+		fmt.Fprintf(w, "  none resolved\n")
+		fmt.Fprintf(
+			w,
+			"  hint: query deps(<target>) and let -mnemonic filter consumers; mnemonic(...) omits producer actions\n\n",
+		)
+		return
+	}
+	fmt.Fprintf(w, "  consumers  producer\n")
+	for i, use := range producers {
+		if i >= limit {
+			break
+		}
+		fmt.Fprintf(
+			w,
+			"  %9d  %s [primary: %s; outputs: %d]\n",
+			use.consumers,
+			producerName(use.producer),
+			use.producer.primaryOutputPath,
+			use.producer.outputCount,
+		)
+	}
+	fmt.Fprintf(w, "\n")
+}
+
+func producerName(producer producer) string {
+	if producer.target == "" {
+		return producer.mnemonic
+	}
+	return producer.mnemonic + " " + producer.target
 }
 
 func writeActionSummaries(w io.Writer, title string, actions []actionSummary, limit int) {

--- a/internal/cmd/linuxobjectinputreport/main_test.go
+++ b/internal/cmd/linuxobjectinputreport/main_test.go
@@ -60,6 +60,9 @@ func TestReportSharedInputs(t *testing.T) {
 		"include/linux/kernel.h",
 		"high-fanout non-header source inputs",
 		"none",
+		"producer fanout (unique LinuxObjectCompile consumer actions; producers present in aquery)",
+		"producer-resolved input artifacts: 0 / 3 unique inputs",
+		"hint: query deps(<target>)",
 		"largest actions by input count",
 		"//:init_main",
 	} {
@@ -67,6 +70,151 @@ func TestReportSharedInputs(t *testing.T) {
 			t.Fatalf("report missing %q:\n%s", want, got)
 		}
 	}
+}
+
+func TestProducerFanoutCountsUniqueConsumers(t *testing.T) {
+	aq := &aqueryOutput{
+		Artifacts: []artifact{
+			{ID: 1, PathFragmentID: 2},
+			{ID: 2, PathFragmentID: 3},
+		},
+		Actions: []action{
+			{
+				TargetID:        1,
+				Mnemonic:        "LinuxGeneratedHeaders",
+				OutputIDs:       []int{1, 2},
+				PrimaryOutputID: 1,
+			},
+			{
+				TargetID:       2,
+				Mnemonic:       "LinuxObjectCompile",
+				InputDepSetIDs: []int{1},
+			},
+			{
+				TargetID:       3,
+				Mnemonic:       "LinuxObjectCompile",
+				InputDepSetIDs: []int{2},
+			},
+		},
+		Targets: []target{
+			{ID: 1, Label: "//:generated_headers"},
+			{ID: 2, Label: "//:first_consumer"},
+			{ID: 3, Label: "//:second_consumer"},
+		},
+		DepSetOfFiles: []depSet{
+			{
+				ID:                  1,
+				DirectArtifactIDs:   []int{1, 2},
+				TransitiveDepSetIDs: []int{3},
+			},
+			{ID: 2, DirectArtifactIDs: []int{2}},
+			{ID: 3, DirectArtifactIDs: []int{1}},
+		},
+		PathFragments: []pathFragment{
+			{ID: 1, Label: "bazel-out"},
+			{ID: 2, Label: "generated_headers", ParentID: 1},
+			{ID: 3, Label: "generated_headers.params", ParentID: 1},
+		},
+	}
+
+	got := renderReport(t, aq)
+	want := "2  LinuxGeneratedHeaders //:generated_headers [primary: bazel-out/generated_headers; outputs: 2]"
+	if !strings.Contains(got, want) {
+		t.Fatalf("producer fanout missing %q:\n%s", want, got)
+	}
+	if count := strings.Count(got, "LinuxGeneratedHeaders //:generated_headers"); count != 1 {
+		t.Fatalf("producer emitted %d rows, want 1:\n%s", count, got)
+	}
+	if !strings.Contains(got, "producer-resolved input artifacts: 2 / 2 unique inputs") {
+		t.Fatalf("producer coverage is incorrect:\n%s", got)
+	}
+}
+
+func TestProducerFanoutKeepsDistinctActionsWithSameOwner(t *testing.T) {
+	aq := &aqueryOutput{
+		Artifacts: []artifact{
+			{ID: 1, PathFragmentID: 2},
+			{ID: 2, PathFragmentID: 3},
+		},
+		Actions: []action{
+			{
+				TargetID:        1,
+				ConfigurationID: 2,
+				Mnemonic:        "Generate",
+				OutputIDs:       []int{2},
+				PrimaryOutputID: 2,
+			},
+			{
+				TargetID:        1,
+				ConfigurationID: 1,
+				Mnemonic:        "Generate",
+				OutputIDs:       []int{1},
+				PrimaryOutputID: 1,
+			},
+			{
+				TargetID:       2,
+				Mnemonic:       "LinuxObjectCompile",
+				InputDepSetIDs: []int{1},
+			},
+		},
+		Targets: []target{
+			{ID: 1, Label: "//:shared_owner"},
+			{ID: 2, Label: "//:consumer"},
+		},
+		DepSetOfFiles: []depSet{
+			{ID: 1, DirectArtifactIDs: []int{1, 2}},
+		},
+		PathFragments: []pathFragment{
+			{ID: 1, Label: "bazel-out"},
+			{ID: 2, Label: "a.out", ParentID: 1},
+			{ID: 3, Label: "b.out", ParentID: 1},
+		},
+	}
+
+	got := renderReport(t, aq)
+	if count := strings.Count(got, "Generate //:shared_owner"); count != 2 {
+		t.Fatalf("same-owner producer actions emitted %d rows, want 2:\n%s", count, got)
+	}
+	first := strings.Index(got, "Generate //:shared_owner [primary: bazel-out/a.out; outputs: 1]")
+	second := strings.Index(got, "Generate //:shared_owner [primary: bazel-out/b.out; outputs: 1]")
+	if first < 0 || second < 0 {
+		t.Fatalf("producer rows are missing:\n%s", got)
+	}
+	if first >= second {
+		t.Fatalf("producer rows are not deterministically sorted by primary output:\n%s", got)
+	}
+}
+
+func TestDuplicateProducerOwnershipFails(t *testing.T) {
+	_, err := newModel(&aqueryOutput{
+		Actions: []action{
+			{Mnemonic: "FirstProducer", OutputIDs: []int{1}},
+			{Mnemonic: "SecondProducer", OutputIDs: []int{1}},
+		},
+	})
+	if err == nil {
+		t.Fatal("newModel() succeeded with duplicate output ownership")
+	}
+	if !strings.Contains(err.Error(), "artifact 1 is output by multiple actions (0 and 1)") {
+		t.Fatalf("newModel() error = %q", err)
+	}
+}
+
+func renderReport(t *testing.T, aq *aqueryOutput) string {
+	t.Helper()
+	model, err := newModel(aq)
+	if err != nil {
+		t.Fatalf("newModel() failed: %v", err)
+	}
+	var out bytes.Buffer
+	if err := writeReport(&out, model, reportOptions{
+		mnemonic:  "LinuxObjectCompile",
+		top:       10,
+		sharedPct: 100,
+	}); err != nil {
+		t.Fatalf("writeReport() failed: %v", err)
+	}
+	return out.String()
 }
 
 func writeFile(t *testing.T, root, name, content string) {


### PR DESCRIPTION
## Summary

- identify generated-input producers by action instance rather than mnemonic and target text
- count each producer once per consuming compile action, even when several outputs are consumed
- report producer coverage and explain the `deps(...)` query required to retain producer actions
- reject malformed action graphs where two actions claim the same output artifact

## Why

The experimental report counted artifact-use edges as producer fanout. A producer with nine outputs consumed by one compile therefore appeared to have fanout nine. This change gives fanout its expected meaning: unique consuming actions.

## Stack

First open PR in the stack, based directly on `main`. The core report from #16 is already merged.

## Validation

- `bazel test //internal/cmd/linuxobjectinputreport:linuxobjectinputreport_test //:gazelle_test //:buildifier_test`
- real Bazel 9.1 `deps(...)` aquery reports producer coverage and fanout
- mnemonic-filtered aquery reports zero coverage with the corrective query hint