### PR TITLE
tools: measure materialized input bytes

### DIFF
--- a/internal/cmd/linuxobjectinputreport/main.go
+++ b/internal/cmd/linuxobjectinputreport/main.go
@@ -5,13 +5,17 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 )
 
 type aqueryOutput struct {
@@ -23,8 +27,9 @@ type aqueryOutput struct {
 }
 
 type artifact struct {
-	ID             int `json:"id"`
-	PathFragmentID int `json:"pathFragmentId"`
+	ID             int  `json:"id"`
+	PathFragmentID int  `json:"pathFragmentId"`
+	IsTreeArtifact bool `json:"isTreeArtifact"`
 }
 
 type action struct {
@@ -58,16 +63,20 @@ type reportOptions struct {
 	mnemonic  string
 	top       int
 	sharedPct int
+	execroot  string
 }
 
 type inputUse struct {
-	path  string
-	count int
+	path        string
+	count       int
+	measurement *byteMeasurement
 }
 
 type actionSummary struct {
-	label string
-	count int
+	label         string
+	count         int
+	bytes         int64
+	bytesComplete bool
 }
 
 type producerID int
@@ -92,6 +101,7 @@ func main() {
 	flag.StringVar(&opts.mnemonic, "mnemonic", "LinuxObjectCompile", "Action mnemonic to report.")
 	flag.IntVar(&opts.top, "top", 20, "Number of top entries to print per section.")
 	flag.IntVar(&opts.sharedPct, "shared_pct", 80, "Minimum action percentage for high-fanout input sections.")
+	flag.StringVar(&opts.execroot, "execroot", "", "Optional Bazel execution root used to measure materialized input bytes.")
 	flag.Parse()
 
 	if err := run(os.Stdout, opts); err != nil {
@@ -143,6 +153,7 @@ func readInput(path string) ([]byte, error) {
 type model struct {
 	aq               *aqueryOutput
 	artifactPath     map[int]string
+	artifacts        map[int]artifact
 	depSets          map[int]depSet
 	targetLabels     map[int]string
 	artifactProducer map[int]producerID
@@ -153,6 +164,7 @@ func newModel(aq *aqueryOutput) (*model, error) {
 	m := &model{
 		aq:               aq,
 		artifactPath:     map[int]string{},
+		artifacts:        map[int]artifact{},
 		depSets:          map[int]depSet{},
 		targetLabels:     map[int]string{},
 		artifactProducer: map[int]producerID{},
@@ -163,6 +175,7 @@ func newModel(aq *aqueryOutput) (*model, error) {
 	}
 	for _, artifact := range aq.Artifacts {
 		m.artifactPath[artifact.ID] = resolvePathFragment(fragments, artifact.PathFragmentID)
+		m.artifacts[artifact.ID] = artifact
 	}
 	for _, depSet := range aq.DepSetOfFiles {
 		m.depSets[depSet.ID] = depSet
@@ -272,14 +285,28 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 		return fmt.Errorf("no actions with mnemonic %q", opts.mnemonic)
 	}
 
+	var measurer *byteMeasurer
+	if opts.execroot != "" {
+		var err error
+		measurer, err = newByteMeasurer(opts.execroot, m)
+		if err != nil {
+			return err
+		}
+	}
+
 	actionSummaries := make([]actionSummary, 0, len(actions))
 	inputCounts := make([]int, 0, len(actions))
+	completeActionBytes := make([]int64, 0, len(actions))
 	inputUses := map[int]*inputUse{}
 	producerConsumerCounts := make([]int, len(m.producers))
 	producerSeenGeneration := make([]int, len(m.producers))
+	actionByteOverflows := 0
 
 	for actionIndex, action := range actions {
 		inputs := m.actionInputs(action)
+		actionFiles := uniqueFiles{}
+		bytesComplete := measurer != nil
+		actionOverflow := false
 		for artifactID := range inputs {
 			path := m.artifactPath[artifactID]
 			use := inputUses[artifactID]
@@ -288,6 +315,20 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 				inputUses[artifactID] = use
 			}
 			use.count++
+			if measurer != nil {
+				measurement := measurer.measureArtifact(artifactID)
+				use.measurement = measurement
+				if !measurement.complete {
+					bytesComplete = false
+				}
+				if err := actionFiles.merge(&measurement.files); err != nil {
+					bytesComplete = false
+					if !actionOverflow {
+						actionByteOverflows++
+						actionOverflow = true
+					}
+				}
+			}
 			if id, ok := m.artifactProducer[artifactID]; ok {
 				if producerSeenGeneration[id] != actionIndex+1 {
 					producerSeenGeneration[id] = actionIndex + 1
@@ -297,27 +338,62 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 		}
 		inputCounts = append(inputCounts, len(inputs))
 		actionSummaries = append(actionSummaries, actionSummary{
-			label: m.targetLabels[action.TargetID],
-			count: len(inputs),
+			label:         m.targetLabels[action.TargetID],
+			count:         len(inputs),
+			bytes:         actionFiles.bytes,
+			bytesComplete: bytesComplete,
 		})
+		if bytesComplete {
+			completeActionBytes = append(completeActionBytes, actionFiles.bytes)
+		}
 	}
 
 	fmt.Fprintf(w, "Linux object input report\n")
 	fmt.Fprintf(w, "mnemonic: %s\n", opts.mnemonic)
 	fmt.Fprintf(w, "actions: %d\n", len(actions))
 	fmt.Fprintf(w, "input count min/p50/p95/max: %s\n", intStats(inputCounts))
+	if measurer == nil {
+		fmt.Fprintf(w, "materialized input bytes: disabled (pass -execroot)\n")
+	} else {
+		unavailableInputs, unavailableUses, issues := byteCoverage(inputUses)
+		fmt.Fprintf(w, "byte accounting: materialized file bytes deduplicated by local file identity under %s\n", measurer.execroot)
+		fmt.Fprintf(
+			w,
+			"byte coverage: %d / %d actions complete; %d distinct inputs unavailable (%d action uses)\n",
+			len(completeActionBytes),
+			len(actions),
+			unavailableInputs,
+			unavailableUses,
+		)
+		if actionByteOverflows != 0 {
+			issues[byteIssueOverflow] += actionByteOverflows
+		}
+		if len(issues) != 0 {
+			fmt.Fprintf(w, "byte issues: %s\n", formatByteIssues(issues))
+		}
+		if len(completeActionBytes) == 0 {
+			fmt.Fprintf(w, "materialized input bytes: unavailable (no complete actions)\n")
+		} else {
+			fmt.Fprintf(
+				w,
+				"materialized input bytes min/p50/p95/max (%d complete actions): %s\n",
+				len(completeActionBytes),
+				byteStats(completeActionBytes),
+			)
+		}
+	}
 	fmt.Fprintf(w, "\n")
 
 	threshold := ceilDiv(len(actions)*opts.sharedPct, 100)
 	writeTopInputs(w, "high-fanout inputs", topInputs(inputUses, func(use *inputUse) bool {
 		return use.count >= threshold
-	}), opts.top, len(actions))
+	}), opts.top, len(actions), measurer != nil)
 	writeTopInputs(w, "high-fanout non-tool inputs", topInputs(inputUses, func(use *inputUse) bool {
 		return use.count >= threshold && !isToolchainLikeInput(use.path)
-	}), opts.top, len(actions))
+	}), opts.top, len(actions), measurer != nil)
 	writeTopInputs(w, "high-fanout non-header source inputs", topInputs(inputUses, func(use *inputUse) bool {
 		return use.count >= threshold && isSourceLikeNonHeader(use.path)
-	}), opts.top, len(actions))
+	}), opts.top, len(actions), measurer != nil)
 	resolvedProducerInputs := 0
 	for artifactID := range inputUses {
 		if _, ok := m.artifactProducer[artifactID]; ok {
@@ -333,6 +409,14 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 		len(inputUses),
 	)
 	writeActionSummaries(w, "largest actions by input count", topActionSummaries(actionSummaries), opts.top)
+	if measurer != nil {
+		writeByteActionSummaries(
+			w,
+			"largest complete actions by materialized input bytes",
+			topActionSummariesByBytes(actionSummaries),
+			opts.top,
+		)
+	}
 	return nil
 }
 
@@ -396,6 +480,25 @@ func topActionSummaries(actions []actionSummary) []actionSummary {
 	return out
 }
 
+func topActionSummariesByBytes(actions []actionSummary) []actionSummary {
+	out := make([]actionSummary, 0, len(actions))
+	for _, action := range actions {
+		if action.bytesComplete {
+			out = append(out, action)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].bytes != out[j].bytes {
+			return out[i].bytes > out[j].bytes
+		}
+		if out[i].count != out[j].count {
+			return out[i].count > out[j].count
+		}
+		return out[i].label < out[j].label
+	})
+	return out
+}
+
 func topProducerUses(producers []producer, consumerCounts []int) []producerUse {
 	out := make([]producerUse, 0, len(producers))
 	for i, producer := range producers {
@@ -428,7 +531,7 @@ func topProducerUses(producers []producer, consumerCounts []int) []producerUse {
 	return out
 }
 
-func writeTopInputs(w io.Writer, title string, inputs []inputUse, limit int, actionCount int) {
+func writeTopInputs(w io.Writer, title string, inputs []inputUse, limit int, actionCount int, showBytes bool) {
 	fmt.Fprintf(w, "%s:\n", title)
 	if len(inputs) == 0 {
 		fmt.Fprintf(w, "  none\n\n")
@@ -439,7 +542,18 @@ func writeTopInputs(w io.Writer, title string, inputs []inputUse, limit int, act
 			break
 		}
 		pct := float64(input.count) * 100 / float64(actionCount)
-		fmt.Fprintf(w, "  %5d %6.1f%%  %s\n", input.count, pct, input.path)
+		if showBytes {
+			fmt.Fprintf(
+				w,
+				"  %5d %6.1f%% %10s  %s\n",
+				input.count,
+				pct,
+				measurementByteDisplay(input.measurement),
+				input.path,
+			)
+		} else {
+			fmt.Fprintf(w, "  %5d %6.1f%%  %s\n", input.count, pct, input.path)
+		}
 	}
 	fmt.Fprintf(w, "\n")
 }
@@ -501,6 +615,60 @@ func writeActionSummaries(w io.Writer, title string, actions []actionSummary, li
 	fmt.Fprintf(w, "\n")
 }
 
+func writeByteActionSummaries(w io.Writer, title string, actions []actionSummary, limit int) {
+	fmt.Fprintf(w, "%s:\n", title)
+	if len(actions) == 0 {
+		fmt.Fprintf(w, "  none\n\n")
+		return
+	}
+	for i, action := range actions {
+		if i >= limit {
+			break
+		}
+		fmt.Fprintf(w, "  %10s %5d inputs  %s\n", formatBytes(action.bytes), action.count, action.label)
+	}
+	fmt.Fprintf(w, "\n")
+}
+
+func byteCoverage(inputUses map[int]*inputUse) (int, int, map[byteIssue]int) {
+	unavailableInputs := 0
+	unavailableUses := 0
+	issues := map[byteIssue]int{}
+	for _, use := range inputUses {
+		if use.measurement == nil || use.measurement.complete {
+			continue
+		}
+		unavailableInputs++
+		unavailableUses += use.count
+		for issue, count := range use.measurement.issues {
+			issues[issue] += count
+		}
+	}
+	return unavailableInputs, unavailableUses, issues
+}
+
+func formatByteIssues(issues map[byteIssue]int) string {
+	names := make([]string, 0, len(issues))
+	for issue, count := range issues {
+		names = append(names, fmt.Sprintf("%s=%d", issue, count))
+	}
+	sort.Strings(names)
+	return strings.Join(names, " ")
+}
+
+func measurementByteDisplay(measurement *byteMeasurement) string {
+	if measurement == nil {
+		return "?"
+	}
+	if measurement.complete {
+		return formatBytes(measurement.files.bytes)
+	}
+	if measurement.files.bytes == 0 {
+		return "?"
+	}
+	return ">=" + formatBytes(measurement.files.bytes)
+}
+
 func isSourceLikeNonHeader(path string) bool {
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".c", ".cc", ".cpp", ".s", ".lds", ".dts", ".dtsi", ".asn1":
@@ -524,7 +692,33 @@ func intStats(values []int) string {
 	return fmt.Sprintf("%d / %d / %d / %d", values[0], percentileInt(values, 50), percentileInt(values, 95), values[len(values)-1])
 }
 
+func byteStats(values []int64) string {
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return fmt.Sprintf(
+		"%s / %s / %s / %s",
+		formatBytes(sorted[0]),
+		formatBytes(percentileInt64(sorted, 50)),
+		formatBytes(percentileInt64(sorted, 95)),
+		formatBytes(sorted[len(sorted)-1]),
+	)
+}
+
 func percentileInt(values []int, percentile int) int {
+	if len(values) == 0 {
+		return 0
+	}
+	index := ceilDiv(len(values)*percentile, 100) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(values) {
+		index = len(values) - 1
+	}
+	return values[index]
+}
+
+func percentileInt64(values []int64, percentile int) int64 {
 	if len(values) == 0 {
 		return 0
 	}
@@ -540,4 +734,260 @@ func percentileInt(values []int, percentile int) int {
 
 func ceilDiv(n, d int) int {
 	return (n + d - 1) / d
+}
+
+func formatBytes(value int64) string {
+	const unit = int64(1024)
+	if value < unit {
+		return fmt.Sprintf("%d B", value)
+	}
+	units := []string{"KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
+	divisor := unit
+	unitIndex := 0
+	for value/divisor >= unit && unitIndex < len(units)-1 {
+		divisor *= unit
+		unitIndex++
+	}
+	return fmt.Sprintf("%.2f %s", float64(value)/float64(divisor), units[unitIndex])
+}
+
+type byteIssue string
+
+const (
+	byteIssueBrokenSymlink  byteIssue = "broken-symlink"
+	byteIssueIO             byteIssue = "io-error"
+	byteIssueNotFound       byteIssue = "not-found"
+	byteIssueOverflow       byteIssue = "overflow"
+	byteIssuePermission     byteIssue = "permission"
+	byteIssueSpecialFile    byteIssue = "special-file"
+	byteIssueSymlinkCycle   byteIssue = "symlink-cycle"
+	byteIssueTypeMismatch   byteIssue = "type-mismatch"
+	byteIssueUnmaterialized byteIssue = "unmaterialized"
+)
+
+type sameFileSet struct {
+	bySize map[int64][]os.FileInfo
+}
+
+func (s *sameFileSet) contains(info os.FileInfo) bool {
+	for _, existing := range s.bySize[info.Size()] {
+		if os.SameFile(existing, info) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *sameFileSet) add(info os.FileInfo) bool {
+	if s.contains(info) {
+		return false
+	}
+	if s.bySize == nil {
+		s.bySize = map[int64][]os.FileInfo{}
+	}
+	size := info.Size()
+	s.bySize[size] = append(s.bySize[size], info)
+	return true
+}
+
+type uniqueFiles struct {
+	identities sameFileSet
+	files      []os.FileInfo
+	bytes      int64
+}
+
+func (f *uniqueFiles) add(info os.FileInfo) error {
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", info.Name())
+	}
+	if !f.identities.add(info) {
+		return nil
+	}
+	size := info.Size()
+	if size < 0 || size > math.MaxInt64-f.bytes {
+		return fmt.Errorf("materialized byte count overflows int64")
+	}
+	f.files = append(f.files, info)
+	f.bytes += size
+	return nil
+}
+
+func (f *uniqueFiles) merge(other *uniqueFiles) error {
+	for _, info := range other.files {
+		if err := f.add(info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type byteMeasurement struct {
+	files    uniqueFiles
+	complete bool
+	issues   map[byteIssue]int
+}
+
+func newByteMeasurement() *byteMeasurement {
+	return &byteMeasurement{
+		complete: true,
+		issues:   map[byteIssue]int{},
+	}
+}
+
+func (m *byteMeasurement) addIssue(issue byteIssue) {
+	m.complete = false
+	m.issues[issue]++
+}
+
+type byteMeasurer struct {
+	execroot string
+	model    *model
+	cache    map[int]*byteMeasurement
+}
+
+func newByteMeasurer(execroot string, model *model) (*byteMeasurer, error) {
+	absolute, err := filepath.Abs(execroot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve -execroot %q: %w", execroot, err)
+	}
+	info, err := os.Stat(absolute)
+	if err != nil {
+		return nil, fmt.Errorf("stat -execroot %q: %w", absolute, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("-execroot %q is not a directory", absolute)
+	}
+	return &byteMeasurer{
+		execroot: absolute,
+		model:    model,
+		cache:    map[int]*byteMeasurement{},
+	}, nil
+}
+
+func (m *byteMeasurer) measureArtifact(artifactID int) *byteMeasurement {
+	if measurement, ok := m.cache[artifactID]; ok {
+		return measurement
+	}
+
+	measurement := newByteMeasurement()
+	m.cache[artifactID] = measurement
+	path := m.model.artifactPath[artifactID]
+	if path == "" {
+		measurement.addIssue(byteIssueNotFound)
+		return measurement
+	}
+	relative := filepath.Clean(filepath.FromSlash(path))
+	if filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		measurement.addIssue(byteIssueIO)
+		return measurement
+	}
+
+	missingIssue := byteIssueNotFound
+	if _, ok := m.model.artifactProducer[artifactID]; ok {
+		missingIssue = byteIssueUnmaterialized
+	}
+	state := scanState{}
+	artifact := m.model.artifacts[artifactID]
+	m.scanPath(
+		filepath.Join(m.execroot, relative),
+		artifact.IsTreeArtifact,
+		missingIssue,
+		measurement,
+		&state,
+	)
+	return measurement
+}
+
+type scanState struct {
+	activeDirectories  []os.FileInfo
+	visitedDirectories sameFileSet
+}
+
+func (m *byteMeasurer) scanPath(
+	path string,
+	expectDirectory bool,
+	missingIssue byteIssue,
+	measurement *byteMeasurement,
+	state *scanState,
+) {
+	info, err := os.Stat(path)
+	if err != nil {
+		measurement.addIssue(classifyPathError(path, err, missingIssue))
+		return
+	}
+	if info.Mode().IsRegular() {
+		if expectDirectory {
+			measurement.addIssue(byteIssueTypeMismatch)
+			return
+		}
+		if err := measurement.files.add(info); err != nil {
+			measurement.addIssue(byteIssueOverflow)
+		}
+		return
+	}
+	if info.IsDir() {
+		m.scanDirectory(path, info, measurement, state)
+		return
+	}
+	if expectDirectory {
+		measurement.addIssue(byteIssueTypeMismatch)
+	} else {
+		measurement.addIssue(byteIssueSpecialFile)
+	}
+}
+
+func (m *byteMeasurer) scanDirectory(
+	path string,
+	info os.FileInfo,
+	measurement *byteMeasurement,
+	state *scanState,
+) {
+	for _, active := range state.activeDirectories {
+		if os.SameFile(active, info) {
+			measurement.addIssue(byteIssueSymlinkCycle)
+			return
+		}
+	}
+	if !state.visitedDirectories.add(info) {
+		return
+	}
+
+	state.activeDirectories = append(state.activeDirectories, info)
+	defer func() {
+		state.activeDirectories = state.activeDirectories[:len(state.activeDirectories)-1]
+	}()
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		measurement.addIssue(classifyPathError(path, err, byteIssueNotFound))
+		return
+	}
+	for _, entry := range entries {
+		m.scanPath(
+			filepath.Join(path, entry.Name()),
+			false,
+			byteIssueNotFound,
+			measurement,
+			state,
+		)
+	}
+}
+
+func classifyPathError(path string, err error, missingIssue byteIssue) byteIssue {
+	if errors.Is(err, syscall.ELOOP) {
+		return byteIssueSymlinkCycle
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		if info, lstatErr := os.Lstat(path); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+			return byteIssueBrokenSymlink
+		}
+		return missingIssue
+	}
+	if errors.Is(err, fs.ErrPermission) {
+		return byteIssuePermission
+	}
+	if info, lstatErr := os.Lstat(path); lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		return byteIssueBrokenSymlink
+	}
+	return byteIssueIO
 }

--- a/internal/cmd/linuxobjectinputreport/main_test.go
+++ b/internal/cmd/linuxobjectinputreport/main_test.go
@@ -57,6 +57,7 @@ func TestReportSharedInputs(t *testing.T) {
 	for _, want := range []string{
 		"actions: 2",
 		"input count min/p50/p95/max: 2 / 2 / 2 / 2",
+		"materialized input bytes: disabled (pass -execroot)",
 		"include/linux/kernel.h",
 		"high-fanout non-header source inputs",
 		"none",
@@ -200,21 +201,292 @@ func TestDuplicateProducerOwnershipFails(t *testing.T) {
 	}
 }
 
+func TestMaterializedBytesDeduplicateAliases(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "data", "12345")
+	writeFile(t, dir, "empty", "")
+	writeFile(t, dir, "copy", "12345")
+	if err := os.Link(filepath.Join(dir, "data"), filepath.Join(dir, "hardlink")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("data", filepath.Join(dir, "symlink")); err != nil {
+		t.Fatal(err)
+	}
+
+	got := renderReportWithOptions(t, inputAquery(
+		inputArtifact{path: "data"},
+		inputArtifact{path: "empty"},
+		inputArtifact{path: "hardlink"},
+		inputArtifact{path: "symlink"},
+		inputArtifact{path: "copy"},
+	), reportOptions{
+		mnemonic:  "LinuxObjectCompile",
+		top:       10,
+		sharedPct: 100,
+		execroot:  dir,
+	})
+
+	for _, want := range []string{
+		"byte coverage: 1 / 1 actions complete; 0 distinct inputs unavailable (0 action uses)",
+		"materialized input bytes min/p50/p95/max (1 complete actions): 10 B / 10 B / 10 B / 10 B",
+		"largest complete actions by materialized input bytes:",
+		"10 B     5 inputs  //:consumer",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("report missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestMaterializedBytesReportMissingInputs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "present", "data")
+	aq := inputAquery(
+		inputArtifact{path: "present"},
+		inputArtifact{path: "generated-missing"},
+		inputArtifact{path: "source-missing"},
+	)
+	aq.Actions = append([]action{{
+		TargetID:        2,
+		Mnemonic:        "Generate",
+		OutputIDs:       []int{2},
+		PrimaryOutputID: 2,
+	}}, aq.Actions...)
+	aq.Targets = append(aq.Targets, target{ID: 2, Label: "//:generator"})
+
+	got := renderReportWithOptions(t, aq, reportOptions{
+		mnemonic:  "LinuxObjectCompile",
+		top:       10,
+		sharedPct: 100,
+		execroot:  dir,
+	})
+
+	for _, want := range []string{
+		"byte coverage: 0 / 1 actions complete; 2 distinct inputs unavailable (2 action uses)",
+		"byte issues: not-found=1 unmaterialized=1",
+		"materialized input bytes: unavailable (no complete actions)",
+		"largest complete actions by materialized input bytes:\n  none",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("report missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestMaterializedByteStatsUseCompleteActions(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "present", "abc")
+	aq := inputAquery(
+		inputArtifact{path: "present"},
+		inputArtifact{path: "missing"},
+	)
+	aq.Actions = []action{
+		{TargetID: 1, Mnemonic: "LinuxObjectCompile", InputDepSetIDs: []int{1}},
+		{TargetID: 2, Mnemonic: "LinuxObjectCompile", InputDepSetIDs: []int{2}},
+	}
+	aq.Targets = []target{
+		{ID: 1, Label: "//:complete"},
+		{ID: 2, Label: "//:incomplete"},
+	}
+	aq.DepSetOfFiles = []depSet{
+		{ID: 1, DirectArtifactIDs: []int{1}},
+		{ID: 2, DirectArtifactIDs: []int{1, 2}},
+	}
+
+	got := renderReportWithOptions(t, aq, reportOptions{
+		mnemonic:  "LinuxObjectCompile",
+		top:       10,
+		sharedPct: 100,
+		execroot:  dir,
+	})
+
+	for _, want := range []string{
+		"byte coverage: 1 / 2 actions complete; 1 distinct inputs unavailable (1 action uses)",
+		"materialized input bytes min/p50/p95/max (1 complete actions): 3 B / 3 B / 3 B / 3 B",
+		"3 B     1 inputs  //:complete",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("report missing %q:\n%s", want, got)
+		}
+	}
+	byteSectionIndex := strings.Index(got, "largest complete actions by materialized input bytes:")
+	if byteSectionIndex < 0 {
+		t.Fatalf("byte ranking is missing:\n%s", got)
+	}
+	byteSection := got[byteSectionIndex:]
+	if strings.Contains(byteSection, "//:incomplete") {
+		t.Fatalf("incomplete action appeared in byte ranking:\n%s", got)
+	}
+}
+
+func TestMaterializedBytesScanTreeAndDirectoryInputs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "tree/first", "abc")
+	writeFile(t, dir, "tree/nested/second", "de")
+	if err := os.Mkdir(filepath.Join(dir, "empty-tree"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "directory/value", "wxyz")
+
+	got := renderReportWithOptions(t, inputAquery(
+		inputArtifact{path: "tree", tree: true},
+		inputArtifact{path: "empty-tree", tree: true},
+		inputArtifact{path: "directory"},
+	), reportOptions{
+		mnemonic:  "LinuxObjectCompile",
+		top:       10,
+		sharedPct: 100,
+		execroot:  dir,
+	})
+
+	for _, want := range []string{
+		"byte coverage: 1 / 1 actions complete; 0 distinct inputs unavailable (0 action uses)",
+		"materialized input bytes min/p50/p95/max (1 complete actions): 9 B / 9 B / 9 B / 9 B",
+		"9 B     3 inputs  //:consumer",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("report missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestMaterializedBytesReportPartialTree(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "tree/known", "data")
+	if err := os.Symlink("missing", filepath.Join(dir, "tree/broken-first")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("also-missing", filepath.Join(dir, "tree/broken-second")); err != nil {
+		t.Fatal(err)
+	}
+
+	got := renderReportWithOptions(t, inputAquery(
+		inputArtifact{path: "tree", tree: true},
+	), reportOptions{
+		mnemonic:  "LinuxObjectCompile",
+		top:       10,
+		sharedPct: 100,
+		execroot:  dir,
+	})
+
+	for _, want := range []string{
+		"byte coverage: 0 / 1 actions complete; 1 distinct inputs unavailable (1 action uses)",
+		"byte issues: broken-symlink=2",
+		">=4 B  tree",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("report missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestMaterializedBytesReportSymlinkCycle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink("second", filepath.Join(dir, "first")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("first", filepath.Join(dir, "second")); err != nil {
+		t.Fatal(err)
+	}
+
+	got := renderReportWithOptions(t, inputAquery(
+		inputArtifact{path: "first"},
+	), reportOptions{
+		mnemonic:  "LinuxObjectCompile",
+		top:       10,
+		sharedPct: 100,
+		execroot:  dir,
+	})
+
+	if !strings.Contains(got, "byte issues: symlink-cycle=1") {
+		t.Fatalf("report does not classify the symlink cycle:\n%s", got)
+	}
+}
+
+func TestExecrootValidation(t *testing.T) {
+	aq := inputAquery(inputArtifact{path: "input"})
+	for name, execroot := range map[string]string{
+		"missing": filepath.Join(t.TempDir(), "missing"),
+		"file":    writeTempFile(t, "not-a-directory"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			model, err := newModel(aq)
+			if err != nil {
+				t.Fatalf("newModel() failed: %v", err)
+			}
+			err = writeReport(&bytes.Buffer{}, model, reportOptions{
+				mnemonic:  "LinuxObjectCompile",
+				top:       10,
+				sharedPct: 100,
+				execroot:  execroot,
+			})
+			if err == nil || !strings.Contains(err.Error(), "-execroot") {
+				t.Fatalf("writeReport() error = %v, want -execroot validation failure", err)
+			}
+		})
+	}
+}
+
+type inputArtifact struct {
+	path string
+	tree bool
+}
+
+func inputAquery(inputs ...inputArtifact) *aqueryOutput {
+	aq := &aqueryOutput{
+		Actions: []action{{
+			TargetID:       1,
+			Mnemonic:       "LinuxObjectCompile",
+			InputDepSetIDs: []int{1},
+		}},
+		Targets:       []target{{ID: 1, Label: "//:consumer"}},
+		DepSetOfFiles: []depSet{{ID: 1}},
+	}
+	for index, input := range inputs {
+		id := index + 1
+		aq.Artifacts = append(aq.Artifacts, artifact{
+			ID:             id,
+			PathFragmentID: id,
+			IsTreeArtifact: input.tree,
+		})
+		aq.DepSetOfFiles[0].DirectArtifactIDs = append(aq.DepSetOfFiles[0].DirectArtifactIDs, id)
+		aq.PathFragments = append(aq.PathFragments, pathFragment{
+			ID:    id,
+			Label: input.path,
+		})
+	}
+	return aq
+}
+
 func renderReport(t *testing.T, aq *aqueryOutput) string {
+	t.Helper()
+	return renderReportWithOptions(t, aq, reportOptions{
+		mnemonic:  "LinuxObjectCompile",
+		top:       10,
+		sharedPct: 100,
+	})
+}
+
+func renderReportWithOptions(t *testing.T, aq *aqueryOutput, opts reportOptions) string {
 	t.Helper()
 	model, err := newModel(aq)
 	if err != nil {
 		t.Fatalf("newModel() failed: %v", err)
 	}
 	var out bytes.Buffer
-	if err := writeReport(&out, model, reportOptions{
-		mnemonic:  "LinuxObjectCompile",
-		top:       10,
-		sharedPct: 100,
-	}); err != nil {
+	if err := writeReport(&out, model, opts); err != nil {
 		t.Fatalf("writeReport() failed: %v", err)
 	}
 	return out.String()
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func writeFile(t *testing.T, root, name, content string) {


### PR DESCRIPTION
## Summary

- add opt-in `-execroot` accounting for materialized compile inputs
- deduplicate symlink and hardlink aliases by local file identity within each action
- recursively measure Bazel tree artifacts and other directory-valued inputs
- report complete-action percentiles, unavailable-input coverage, categorized issues, and largest complete actions
- preserve partial lower bounds while treating missing, broken, or unmaterialized inputs as unknown rather than zero

## Why

The experimental implementation used `os.Stat` per artifact path. It silently assigned zero bytes to missing and tree inputs and multiplied aliased LLVM multicall binaries, producing misleading rankings. This change explicitly measures a local execroot snapshot and reports its coverage.

## Stack

First remaining open PR in the stack, rebased directly onto `main` after the producer-fanout change merged. This PR contains only the byte-accounting change.

## Validation

- `bazel test //internal/cmd/linuxobjectinputreport:linuxobjectinputreport_test //:gazelle_test //:buildifier_test`
- focused tests cover regular and zero-byte files, hardlink/symlink aliases, missing produced and source inputs, directories/tree artifacts, partial trees, symlink cycles, and execroot validation
- real Bazel 9.1 compile graph reports `228.15 MiB` with complete coverage instead of the experimental implementation's aliased `3.41 GiB`