### PR TITLE
tools: broaden Linux input report coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,8 +455,9 @@ bazel run @linux.bzl//tools:linuxobjectinputreport -- \
 ```
 
 Use the same configuration and platform flags for the build and `aquery`.
-The report filters `LinuxObjectCompile` actions by default; pass `-mnemonic`
-to select another action class. Do not filter the `aquery` itself with
+The report filters `LinuxObjectCompile` actions by default. Passing
+`-mnemonic` replaces that default; repeat the flag to report several action
+classes as one population. Do not filter the `aquery` itself with
 `mnemonic(...)` when producer fanout is needed, because that removes the
 producer actions from the JSON graph.
 

--- a/internal/cmd/linuxobjectinputreport/main.go
+++ b/internal/cmd/linuxobjectinputreport/main.go
@@ -60,7 +60,7 @@ type pathFragment struct {
 
 type reportOptions struct {
 	inputPath string
-	mnemonic  string
+	mnemonics []string
 	top       int
 	sharedPct int
 	execroot  string
@@ -95,14 +95,28 @@ type producerUse struct {
 	consumers int
 }
 
+const defaultCompileMnemonic = "LinuxObjectCompile"
+
+type mnemonicFlag []string
+
+func (m *mnemonicFlag) String() string {
+	return strings.Join(*m, ",")
+}
+
+func (m *mnemonicFlag) Set(value string) error {
+	*m = append(*m, value)
+	return nil
+}
+
 func main() {
-	opts := reportOptions{}
-	flag.StringVar(&opts.inputPath, "input", "", "Path to Bazel aquery JSON proto. Reads stdin when empty or -.")
-	flag.StringVar(&opts.mnemonic, "mnemonic", "LinuxObjectCompile", "Action mnemonic to report.")
-	flag.IntVar(&opts.top, "top", 20, "Number of top entries to print per section.")
-	flag.IntVar(&opts.sharedPct, "shared_pct", 80, "Minimum action percentage for high-fanout input sections.")
-	flag.StringVar(&opts.execroot, "execroot", "", "Optional Bazel execution root used to measure materialized input bytes.")
-	flag.Parse()
+	opts, err := parseOptions(os.Args[1:])
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "linuxobjectinputreport: %v\n", err)
+		os.Exit(2)
+	}
 
 	if err := run(os.Stdout, opts); err != nil {
 		fmt.Fprintf(os.Stderr, "linuxobjectinputreport: %v\n", err)
@@ -110,9 +124,53 @@ func main() {
 	}
 }
 
+func parseOptions(args []string) (reportOptions, error) {
+	opts := reportOptions{}
+	flags := flag.NewFlagSet("linuxobjectinputreport", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	flags.StringVar(&opts.inputPath, "input", "", "Path to Bazel aquery JSON proto. Reads stdin when empty or -.")
+	flags.Var((*mnemonicFlag)(&opts.mnemonics), "mnemonic", "Action mnemonic to include. Repeat to report a union; defaults to LinuxObjectCompile.")
+	flags.IntVar(&opts.top, "top", 20, "Number of top entries to print per section.")
+	flags.IntVar(&opts.sharedPct, "shared_pct", 80, "Minimum action percentage for high-fanout input sections.")
+	flags.StringVar(&opts.execroot, "execroot", "", "Optional Bazel execution root used to measure materialized input bytes.")
+	if err := flags.Parse(args); err != nil {
+		return reportOptions{}, err
+	}
+	if flags.NArg() != 0 {
+		return reportOptions{}, fmt.Errorf("unexpected positional arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	var err error
+	opts.mnemonics, err = normalizeMnemonics(opts.mnemonics)
+	if err != nil {
+		return reportOptions{}, err
+	}
+	return opts, nil
+}
+
+func normalizeMnemonics(values []string) ([]string, error) {
+	if len(values) == 0 {
+		return []string{defaultCompileMnemonic}, nil
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if value == "" {
+			return nil, fmt.Errorf("-mnemonic must not be empty")
+		}
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out, nil
+}
+
 func run(w io.Writer, opts reportOptions) error {
-	if opts.mnemonic == "" {
-		return fmt.Errorf("-mnemonic must not be empty")
+	var err error
+	opts.mnemonics, err = normalizeMnemonics(opts.mnemonics)
+	if err != nil {
+		return err
 	}
 	if opts.top <= 0 {
 		opts.top = 20
@@ -280,14 +338,17 @@ func resolvePathFragment(fragments map[int]pathFragment, id int) string {
 }
 
 func writeReport(w io.Writer, m *model, opts reportOptions) error {
-	actions := m.actionsByMnemonic(opts.mnemonic)
+	mnemonics, err := normalizeMnemonics(opts.mnemonics)
+	if err != nil {
+		return err
+	}
+	actions := m.actionsByMnemonics(mnemonics)
 	if len(actions) == 0 {
-		return fmt.Errorf("no actions with mnemonic %q", opts.mnemonic)
+		return fmt.Errorf("no actions with selected mnemonics %q", strings.Join(mnemonics, ", "))
 	}
 
 	var measurer *byteMeasurer
 	if opts.execroot != "" {
-		var err error
 		measurer, err = newByteMeasurer(opts.execroot, m)
 		if err != nil {
 			return err
@@ -338,7 +399,7 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 		}
 		inputCounts = append(inputCounts, len(inputs))
 		actionSummaries = append(actionSummaries, actionSummary{
-			label:         m.targetLabels[action.TargetID],
+			label:         m.actionName(action),
 			count:         len(inputs),
 			bytes:         actionFiles.bytes,
 			bytesComplete: bytesComplete,
@@ -349,7 +410,7 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 	}
 
 	fmt.Fprintf(w, "Linux object input report\n")
-	fmt.Fprintf(w, "mnemonic: %s\n", opts.mnemonic)
+	fmt.Fprintf(w, "mnemonics: %s\n", strings.Join(mnemonics, ", "))
 	fmt.Fprintf(w, "actions: %d\n", len(actions))
 	fmt.Fprintf(w, "input count min/p50/p95/max: %s\n", intStats(inputCounts))
 	if measurer == nil {
@@ -402,7 +463,6 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 	}
 	writeProducerUses(
 		w,
-		opts.mnemonic,
 		topProducerUses(m.producers, producerConsumerCounts),
 		opts.top,
 		resolvedProducerInputs,
@@ -420,14 +480,30 @@ func writeReport(w io.Writer, m *model, opts reportOptions) error {
 	return nil
 }
 
-func (m *model) actionsByMnemonic(mnemonic string) []action {
+func (m *model) actionsByMnemonics(mnemonics []string) []action {
+	selected := make(map[string]bool, len(mnemonics))
+	for _, mnemonic := range mnemonics {
+		selected[mnemonic] = true
+	}
 	var out []action
 	for _, action := range m.aq.Actions {
-		if action.Mnemonic == mnemonic {
+		if selected[action.Mnemonic] {
 			out = append(out, action)
 		}
 	}
 	return out
+}
+
+func (m *model) actionName(action action) string {
+	name := action.Mnemonic
+	if label := m.targetLabels[action.TargetID]; label != "" {
+		name += " " + label
+	}
+	outputIDs := uniqueInts(action.OutputIDs)
+	if len(outputIDs) != 0 {
+		name += " [primary: " + primaryOutputPath(action.PrimaryOutputID, outputIDs, m.artifactPath) + "]"
+	}
+	return name
 }
 
 func (m *model) actionInputs(action action) map[int]bool {
@@ -560,7 +636,6 @@ func writeTopInputs(w io.Writer, title string, inputs []inputUse, limit int, act
 
 func writeProducerUses(
 	w io.Writer,
-	consumerMnemonic string,
 	producers []producerUse,
 	limit int,
 	resolvedInputCount int,
@@ -568,8 +643,7 @@ func writeProducerUses(
 ) {
 	fmt.Fprintf(
 		w,
-		"producer fanout (unique %s consumer actions; producers present in aquery):\n",
-		consumerMnemonic,
+		"producer fanout (unique selected consumer actions; producers present in aquery):\n",
 	)
 	fmt.Fprintf(w, "  producer-resolved input artifacts: %d / %d unique inputs\n", resolvedInputCount, inputCount)
 	if len(producers) == 0 {
@@ -671,7 +745,7 @@ func measurementByteDisplay(measurement *byteMeasurement) string {
 
 func isSourceLikeNonHeader(path string) bool {
 	switch strings.ToLower(filepath.Ext(path)) {
-	case ".c", ".cc", ".cpp", ".s", ".lds", ".dts", ".dtsi", ".asn1":
+	case ".asn1", ".c", ".c_shipped", ".cc", ".cpp", ".dts", ".dtsi", ".dtso", ".inc", ".lds", ".pl", ".rs", ".s":
 		return true
 	default:
 		return false

--- a/internal/cmd/linuxobjectinputreport/main_test.go
+++ b/internal/cmd/linuxobjectinputreport/main_test.go
@@ -47,7 +47,7 @@ func TestReportSharedInputs(t *testing.T) {
 	var out bytes.Buffer
 	if err := run(&out, reportOptions{
 		inputPath: aquery,
-		mnemonic:  "LinuxObjectCompile",
+		mnemonics: []string{"LinuxObjectCompile"},
 		top:       10,
 		sharedPct: 100,
 	}); err != nil {
@@ -61,7 +61,7 @@ func TestReportSharedInputs(t *testing.T) {
 		"include/linux/kernel.h",
 		"high-fanout non-header source inputs",
 		"none",
-		"producer fanout (unique LinuxObjectCompile consumer actions; producers present in aquery)",
+		"producer fanout (unique selected consumer actions; producers present in aquery)",
 		"producer-resolved input artifacts: 0 / 3 unique inputs",
 		"hint: query deps(<target>)",
 		"largest actions by input count",
@@ -70,6 +70,186 @@ func TestReportSharedInputs(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("report missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestParseOptionsMnemonics(t *testing.T) {
+	opts, err := parseOptions(nil)
+	if err != nil {
+		t.Fatalf("parseOptions() failed: %v", err)
+	}
+	if got, want := strings.Join(opts.mnemonics, ","), "LinuxObjectCompile"; got != want {
+		t.Fatalf("default mnemonics = %q, want %q", got, want)
+	}
+
+	opts, err = parseOptions([]string{
+		"-mnemonic", "LinuxRustc",
+		"-mnemonic", "LinuxVDSOCompile",
+		"-mnemonic", "LinuxRustc",
+	})
+	if err != nil {
+		t.Fatalf("parseOptions() failed: %v", err)
+	}
+	if got, want := strings.Join(opts.mnemonics, ","), "LinuxRustc,LinuxVDSOCompile"; got != want {
+		t.Fatalf("explicit mnemonics = %q, want %q", got, want)
+	}
+
+	if _, err := parseOptions([]string{"-mnemonic", ""}); err == nil {
+		t.Fatal("parseOptions() accepted an empty mnemonic")
+	}
+}
+
+func TestReportMultipleMnemonicsUseOneActionUnion(t *testing.T) {
+	aq := &aqueryOutput{
+		Artifacts: []artifact{
+			{ID: 1, PathFragmentID: 1},
+			{ID: 2, PathFragmentID: 2},
+			{ID: 3, PathFragmentID: 3},
+			{ID: 4, PathFragmentID: 4},
+			{ID: 5, PathFragmentID: 5},
+			{ID: 6, PathFragmentID: 6},
+			{ID: 7, PathFragmentID: 7},
+		},
+		Actions: []action{
+			{
+				TargetID:        1,
+				Mnemonic:        "Generate",
+				OutputIDs:       []int{1},
+				PrimaryOutputID: 1,
+			},
+			{
+				TargetID:        2,
+				Mnemonic:        "LinuxObjectCompile",
+				InputDepSetIDs:  []int{1},
+				OutputIDs:       []int{4},
+				PrimaryOutputID: 4,
+			},
+			{
+				TargetID:        2,
+				Mnemonic:        "LinuxRustc",
+				InputDepSetIDs:  []int{2},
+				OutputIDs:       []int{5},
+				PrimaryOutputID: 5,
+			},
+			{
+				TargetID:        3,
+				Mnemonic:        "CppCompile",
+				InputDepSetIDs:  []int{3},
+				OutputIDs:       []int{7},
+				PrimaryOutputID: 7,
+			},
+		},
+		Targets: []target{
+			{ID: 1, Label: "//:generated"},
+			{ID: 2, Label: "//:kernel"},
+			{ID: 3, Label: "//:unrelated"},
+		},
+		DepSetOfFiles: []depSet{
+			{ID: 1, DirectArtifactIDs: []int{1, 2}},
+			{ID: 2, DirectArtifactIDs: []int{1, 3}},
+			{ID: 3, DirectArtifactIDs: []int{6}},
+		},
+		PathFragments: []pathFragment{
+			{ID: 1, Label: "generated.inc"},
+			{ID: 2, Label: "object-only.c"},
+			{ID: 3, Label: "rust-only.rs"},
+			{ID: 4, Label: "bazel-out/object.o"},
+			{ID: 5, Label: "bazel-out/rust.o"},
+			{ID: 6, Label: "unrelated.c"},
+			{ID: 7, Label: "bazel-out/unrelated.o"},
+		},
+	}
+	opts := reportOptions{
+		mnemonics: []string{
+			"LinuxObjectCompile",
+			"LinuxRustc",
+			"LinuxARM64VDSOCompile",
+			"LinuxObjectCompile",
+		},
+		top:       20,
+		sharedPct: 50,
+	}
+
+	got := renderReportWithOptions(t, aq, opts)
+	for _, want := range []string{
+		"mnemonics: LinuxObjectCompile, LinuxRustc, LinuxARM64VDSOCompile",
+		"actions: 2",
+		"1   50.0%  object-only.c",
+		"1   50.0%  rust-only.rs",
+		"2  Generate //:generated",
+		"LinuxObjectCompile //:kernel [primary: bazel-out/object.o]",
+		"LinuxRustc //:kernel [primary: bazel-out/rust.o]",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("report missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "unrelated.c") || strings.Contains(got, "//:unrelated") {
+		t.Fatalf("report included an action outside the selected mnemonic union:\n%s", got)
+	}
+	if count := strings.Count(got, "Generate //:generated"); count != 1 {
+		t.Fatalf("producer emitted %d rows, want 1:\n%s", count, got)
+	}
+
+	opts.sharedPct = 51
+	got = renderReportWithOptions(t, aq, opts)
+	if strings.Contains(got, "object-only.c") || strings.Contains(got, "rust-only.rs") {
+		t.Fatalf("one-of-two inputs passed a 51%% union threshold:\n%s", got)
+	}
+}
+
+func TestReportRequiresOneSelectedAction(t *testing.T) {
+	model, err := newModel(inputAquery())
+	if err != nil {
+		t.Fatalf("newModel() failed: %v", err)
+	}
+	err = writeReport(&bytes.Buffer{}, model, reportOptions{
+		mnemonics: []string{"LinuxRustc", "LinuxVDSOCompile"},
+		sharedPct: 80,
+	})
+	if err == nil || !strings.Contains(err.Error(), "LinuxRustc, LinuxVDSOCompile") {
+		t.Fatalf("writeReport() error = %v, want empty selected-union error", err)
+	}
+}
+
+func TestSourceLikeNonHeaderExtensions(t *testing.T) {
+	for _, path := range []string{
+		"source.asn1",
+		"source.c",
+		"source.c_shipped",
+		"source.cc",
+		"source.cpp",
+		"source.dts",
+		"source.dtsi",
+		"source.dtso",
+		"source.inc",
+		"source.lds",
+		"source.lds.S",
+		"source.pl",
+		"source.rs",
+		"source.s",
+		"source.S",
+	} {
+		t.Run("positive/"+path, func(t *testing.T) {
+			if !isSourceLikeNonHeader(path) {
+				t.Fatalf("isSourceLikeNonHeader(%q) = false, want true", path)
+			}
+		})
+	}
+	for _, path := range []string{
+		"Kbuild",
+		"Makefile",
+		"source.h",
+		"source.o",
+		"source.c.tmp",
+		"source.dtso.bak",
+		"source.notinc",
+	} {
+		t.Run("negative/"+path, func(t *testing.T) {
+			if isSourceLikeNonHeader(path) {
+				t.Fatalf("isSourceLikeNonHeader(%q) = true, want false", path)
+			}
+		})
 	}
 }
 
@@ -220,7 +400,7 @@ func TestMaterializedBytesDeduplicateAliases(t *testing.T) {
 		inputArtifact{path: "symlink"},
 		inputArtifact{path: "copy"},
 	), reportOptions{
-		mnemonic:  "LinuxObjectCompile",
+		mnemonics: []string{"LinuxObjectCompile"},
 		top:       10,
 		sharedPct: 100,
 		execroot:  dir,
@@ -230,7 +410,7 @@ func TestMaterializedBytesDeduplicateAliases(t *testing.T) {
 		"byte coverage: 1 / 1 actions complete; 0 distinct inputs unavailable (0 action uses)",
 		"materialized input bytes min/p50/p95/max (1 complete actions): 10 B / 10 B / 10 B / 10 B",
 		"largest complete actions by materialized input bytes:",
-		"10 B     5 inputs  //:consumer",
+		"10 B     5 inputs  LinuxObjectCompile //:consumer",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("report missing %q:\n%s", want, got)
@@ -255,7 +435,7 @@ func TestMaterializedBytesReportMissingInputs(t *testing.T) {
 	aq.Targets = append(aq.Targets, target{ID: 2, Label: "//:generator"})
 
 	got := renderReportWithOptions(t, aq, reportOptions{
-		mnemonic:  "LinuxObjectCompile",
+		mnemonics: []string{"LinuxObjectCompile"},
 		top:       10,
 		sharedPct: 100,
 		execroot:  dir,
@@ -294,7 +474,7 @@ func TestMaterializedByteStatsUseCompleteActions(t *testing.T) {
 	}
 
 	got := renderReportWithOptions(t, aq, reportOptions{
-		mnemonic:  "LinuxObjectCompile",
+		mnemonics: []string{"LinuxObjectCompile"},
 		top:       10,
 		sharedPct: 100,
 		execroot:  dir,
@@ -303,7 +483,7 @@ func TestMaterializedByteStatsUseCompleteActions(t *testing.T) {
 	for _, want := range []string{
 		"byte coverage: 1 / 2 actions complete; 1 distinct inputs unavailable (1 action uses)",
 		"materialized input bytes min/p50/p95/max (1 complete actions): 3 B / 3 B / 3 B / 3 B",
-		"3 B     1 inputs  //:complete",
+		"3 B     1 inputs  LinuxObjectCompile //:complete",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("report missing %q:\n%s", want, got)
@@ -333,7 +513,7 @@ func TestMaterializedBytesScanTreeAndDirectoryInputs(t *testing.T) {
 		inputArtifact{path: "empty-tree", tree: true},
 		inputArtifact{path: "directory"},
 	), reportOptions{
-		mnemonic:  "LinuxObjectCompile",
+		mnemonics: []string{"LinuxObjectCompile"},
 		top:       10,
 		sharedPct: 100,
 		execroot:  dir,
@@ -342,7 +522,7 @@ func TestMaterializedBytesScanTreeAndDirectoryInputs(t *testing.T) {
 	for _, want := range []string{
 		"byte coverage: 1 / 1 actions complete; 0 distinct inputs unavailable (0 action uses)",
 		"materialized input bytes min/p50/p95/max (1 complete actions): 9 B / 9 B / 9 B / 9 B",
-		"9 B     3 inputs  //:consumer",
+		"9 B     3 inputs  LinuxObjectCompile //:consumer",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("report missing %q:\n%s", want, got)
@@ -363,7 +543,7 @@ func TestMaterializedBytesReportPartialTree(t *testing.T) {
 	got := renderReportWithOptions(t, inputAquery(
 		inputArtifact{path: "tree", tree: true},
 	), reportOptions{
-		mnemonic:  "LinuxObjectCompile",
+		mnemonics: []string{"LinuxObjectCompile"},
 		top:       10,
 		sharedPct: 100,
 		execroot:  dir,
@@ -392,7 +572,7 @@ func TestMaterializedBytesReportSymlinkCycle(t *testing.T) {
 	got := renderReportWithOptions(t, inputAquery(
 		inputArtifact{path: "first"},
 	), reportOptions{
-		mnemonic:  "LinuxObjectCompile",
+		mnemonics: []string{"LinuxObjectCompile"},
 		top:       10,
 		sharedPct: 100,
 		execroot:  dir,
@@ -415,7 +595,7 @@ func TestExecrootValidation(t *testing.T) {
 				t.Fatalf("newModel() failed: %v", err)
 			}
 			err = writeReport(&bytes.Buffer{}, model, reportOptions{
-				mnemonic:  "LinuxObjectCompile",
+				mnemonics: []string{"LinuxObjectCompile"},
 				top:       10,
 				sharedPct: 100,
 				execroot:  execroot,
@@ -461,7 +641,7 @@ func inputAquery(inputs ...inputArtifact) *aqueryOutput {
 func renderReport(t *testing.T, aq *aqueryOutput) string {
 	t.Helper()
 	return renderReportWithOptions(t, aq, reportOptions{
-		mnemonic:  "LinuxObjectCompile",
+		mnemonics: []string{"LinuxObjectCompile"},
 		top:       10,
 		sharedPct: 100,
 	})


### PR DESCRIPTION
## Summary

- make `-mnemonic` repeatable so related compile action classes can be reported as one explicitly selected population
- preserve `LinuxObjectCompile` as the no-flag default and stable-deduplicate repeated selections
- compute fanout thresholds, percentages, byte statistics, and producer fanout over the selected action union
- identify ranked actions by mnemonic, owner, and primary output
- recognize additional Linux source forms: `.c_shipped`, `.dtso`, `.inc`, `.pl`, and `.rs`

## Why

The single-mnemonic interface cannot compare closely related object-producing action classes in one report. Naively concatenating per-mnemonic results would use the wrong denominator and can double-count duplicate selections. This change treats explicit mnemonic flags as one action set while leaving the established default unchanged.

## Stack

The preceding report PRs are merged. This PR is rebased directly on current `main` and contains only multi-mnemonic/source-coverage support and its documentation and tests.

## Validation

- `go test ./internal/cmd/linuxobjectinputreport`
- `go test -race ./internal/cmd/linuxobjectinputreport`
- `bazel test //internal/cmd/linuxobjectinputreport:linuxobjectinputreport_test //:gazelle_test //:buildifier_test`
- real aquery smoke test selecting `LinuxObjectCompile` and `CppCompile` together
- independent review found no blocking correctness or regression issues