### PR TITLE
Reduce Bazel analysis overhead

### DIFF
--- a/.github/workflows/bazel_cache_report.sh
+++ b/.github/workflows/bazel_cache_report.sh
@@ -24,15 +24,16 @@ if [[ ! -s "${bep}" ]]; then
   exit 0
 fi
 
-metrics="$(
+build_metrics="$(
   jq -c \
-    'select(.buildMetrics.actionSummary != null) | .buildMetrics.actionSummary' \
+    'select(.buildMetrics != null) | .buildMetrics' \
     "${bep}" 2>/dev/null | tail -n 1 || true
 )"
-if [[ -z "${metrics}" ]]; then
+if [[ -z "${build_metrics}" ]]; then
   write_missing_metrics
   exit 0
 fi
+metrics="$(jq -c '.actionSummary // {}' <<<"${build_metrics}")"
 
 values="$(
   jq -r '
@@ -55,6 +56,20 @@ values="$(
   ' <<<"${metrics}"
 )"
 IFS=$'\t' read -r local_hits local_misses shared_hits actions_created actions_executed <<<"${values}"
+
+analysis_values="$(
+  jq -r '
+    def integer: (. // 0) | tonumber;
+    [
+      (.timingMetrics.analysisPhaseTimeInMs | integer),
+      (.targetMetrics.targetsConfigured | integer),
+      (.packageMetrics.packagesLoaded | integer),
+      (.memoryMetrics.peakPostGcHeapSize | integer)
+    ]
+    | @tsv
+  ' <<<"${build_metrics}"
+)"
+IFS=$'\t' read -r analysis_ms targets_configured packages_loaded peak_heap_bytes <<<"${analysis_values}"
 
 cache_lookups=$((local_hits + local_misses))
 effective_hits=$((local_hits + shared_hits))
@@ -84,13 +99,55 @@ miss_reasons="$(
 )"
 runner_summary="$(
   jq -r '
-    [.runnerCount[]? | "\(.name): \(.count)"]
+    [.runnerCount[]? | select(.count != null) | "\(.name): \(.count)"]
     | join(", ")
   ' <<<"${metrics}"
 )"
 process_summary="$(
   grep -E '^INFO: .* processes:' "${log}" 2>/dev/null | tail -n 1 || true
 )"
+profile_values=""
+if [[ -s "${profile}" ]]; then
+  profile_values="$(
+    gzip -cd "${profile}" 2>/dev/null |
+      jq -r '
+        [
+          ([.traceEvents[]?
+            | select(
+                .cat == "Fetching repository"
+                and ((.name // "") | contains("linux_image"))
+              )
+            | {
+                name: .name,
+                duration: (.dur // 0)
+              }]
+            | group_by(.name)
+            | map([.[].duration] | max)
+            | add // 0),
+          ([.traceEvents[]?
+            | select(.name == "Memory usage (Bazel)")
+            | (.args.memory // 0)] | max // 0 | floor),
+          ([.traceEvents[]?
+            | select(.name == "_linux_object_impl")] | length),
+          ([.traceEvents[]?
+            | select(.name == "_linux_object_impl")
+            | (.dur // 0)] | add // 0)
+        ]
+        | @tsv
+      ' 2>/dev/null || true
+  )"
+fi
+linux_image_fetch_us=0
+profile_peak_memory_mib=0
+linux_object_analyses=0
+linux_object_analysis_us=0
+if [[ -n "${profile_values}" ]]; then
+  IFS=$'\t' read -r \
+    linux_image_fetch_us \
+    profile_peak_memory_mib \
+    linux_object_analyses \
+    linux_object_analysis_us <<<"${profile_values}"
+fi
 disk_cache_size="$(
   du -sh "${HOME}/.cache/bazel-disk" 2>/dev/null | awk '{ print $1 }' || true
 )"
@@ -110,6 +167,34 @@ disk_available="$(
   printf '| Effective action-cache hit rate | %s |\n' "${hit_rate}"
   printf '| Actions created | %s |\n' "${actions_created}"
   printf '| Actions executed | %s |\n' "${actions_executed}"
+  if ((analysis_ms > 0)); then
+    printf '| Analysis phase | %d.%03d s |\n' \
+      "$((analysis_ms / 1000))" "$((analysis_ms % 1000))"
+  fi
+  if ((targets_configured > 0)); then
+    printf '| Targets configured | %s |\n' "${targets_configured}"
+  fi
+  if ((packages_loaded > 0)); then
+    printf '| Packages loaded | %s |\n' "${packages_loaded}"
+  fi
+  if ((peak_heap_bytes > 0)); then
+    peak_heap_tenths=$((peak_heap_bytes * 10 / 1048576))
+    printf '| Peak post-GC heap | %d.%d MiB |\n' \
+      "$((peak_heap_tenths / 10))" "$((peak_heap_tenths % 10))"
+  fi
+  if ((profile_peak_memory_mib > 0)); then
+    printf '| Peak Bazel memory (profile) | %s MiB |\n' "${profile_peak_memory_mib}"
+  fi
+  if ((linux_object_analyses > 0)); then
+    printf '| Linux object analysis events (profile) | %s |\n' "${linux_object_analyses}"
+    printf '| Linux object aggregate analysis duration (profile) | %d.%03d s |\n' \
+      "$((linux_object_analysis_us / 1000000))" \
+      "$((linux_object_analysis_us % 1000000 / 1000))"
+  fi
+  if ((linux_image_fetch_us > 0)); then
+    printf '| Linux image repository generation | %d.%03d s |\n' \
+      "$((linux_image_fetch_us / 1000000))" "$((linux_image_fetch_us % 1000000 / 1000))"
+  fi
   if [[ -n "${disk_cache_size}" ]]; then
     printf '| Disk cache on runner | %s |\n' "${disk_cache_size}"
   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,13 @@ jobs:
             targets+=(//internal/tests:path_mapping_test)
             path_mapping_args+=("${BAZEL_PATH_MAPPING}")
           fi
-          bazel --host_jvm_args=-Xmx3g \
+          bazel --host_jvm_args=-Xmx6g \
             --bazelrc="${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc" \
             test "${targets[@]}" \
             "${path_mapping_args[@]}" \
+            --notrack_incremental_state \
+            --nokeep_state_after_build \
+            --discard_analysis_cache \
             --build_event_json_file="${BAZEL_BEP}" \
             --profile="${BAZEL_PROFILE}" \
             2>&1 | tee "${BAZEL_LOG}"
@@ -131,10 +134,13 @@ jobs:
         run: |
           set -euo pipefail
           read -r -a targets <<<"${BAZEL_TARGETS}"
-          bazel --host_jvm_args=-Xmx3g \
+          bazel --host_jvm_args=-Xmx6g \
             --bazelrc="${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc" \
             build "${targets[@]}" \
             --config=path-mapping \
+            --notrack_incremental_state \
+            --nokeep_state_after_build \
+            --discard_analysis_cache \
             --build_event_json_file="${BAZEL_BEP}" \
             --profile="${BAZEL_PROFILE}" \
             2>&1 | tee "${BAZEL_LOG}"
@@ -219,10 +225,13 @@ jobs:
         run: |
           set -euo pipefail
           read -r -a targets <<<"${BAZEL_TARGETS}"
-          bazel --host_jvm_args=-Xmx3g \
+          bazel --host_jvm_args=-Xmx6g \
             --bazelrc="${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc" \
             test "${targets[@]}" \
             --config=path-mapping \
+            --notrack_incremental_state \
+            --nokeep_state_after_build \
+            --discard_analysis_cache \
             --build_event_json_file="${BAZEL_BEP}" \
             --profile="${BAZEL_PROFILE}" \
             2>&1 | tee "${BAZEL_LOG}"
@@ -289,9 +298,12 @@ jobs:
           BAZEL_PROFILE: ${{ runner.temp }}/aya-e2e-${{ matrix.arch }}.profile.gz
         run: |
           set -o pipefail
-          bazel --host_jvm_args=-Xmx3g \
+          bazel --host_jvm_args=-Xmx6g \
             --bazelrc="${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc" \
             test '${{ matrix.target }}' \
+            --notrack_incremental_state \
+            --nokeep_state_after_build \
+            --discard_analysis_cache \
             --build_event_json_file="${BAZEL_BEP}" \
             --profile="${BAZEL_PROFILE}" \
             2>&1 | tee "${BAZEL_LOG}"

--- a/.github/workflows/host-platforms.yml
+++ b/.github/workflows/host-platforms.yml
@@ -25,8 +25,10 @@ jobs:
         include:
           - host: macOS
             runner: macos-latest
+            heap: 4g
           - host: Windows
             runner: windows-latest
+            heap: 6g
     defaults:
       run:
         shell: bash
@@ -55,12 +57,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ../.ci-artifacts
-          bazel --bazelrc="${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc" \
+          bazel --host_jvm_args=-Xmx${{ matrix.heap }} \
+            --bazelrc="${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc" \
             build \
             //:x86_64_kernel \
             //:x86_64_debug_kernel \
             //:x86_64_lz4_kernel \
             --config=path-mapping \
+            --notrack_incremental_state \
+            --nokeep_state_after_build \
+            --discard_analysis_cache \
             --build_event_json_file="${BAZEL_BEP}" \
             --profile="${BAZEL_PROFILE}" \
             2>&1 | tee "${BAZEL_LOG}"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -81,7 +81,18 @@ register_toolchains(
 )
 
 register_toolchains(
-    "@llvm_toolchains//:all",
+    "@llvm_toolchains//:linux_aarch64_to_linux_aarch64",
+    "@llvm_toolchains//:linux_aarch64_to_linux_x86_64",
+    "@llvm_toolchains//:linux_x86_64_to_linux_aarch64",
+    "@llvm_toolchains//:linux_x86_64_to_linux_x86_64",
+    "@llvm_toolchains//:macos_aarch64_to_linux_aarch64",
+    "@llvm_toolchains//:macos_aarch64_to_linux_x86_64",
+    "@llvm_toolchains//:macos_x86_64_to_linux_aarch64",
+    "@llvm_toolchains//:macos_x86_64_to_linux_x86_64",
+    "@llvm_toolchains//:windows_aarch64_to_linux_aarch64",
+    "@llvm_toolchains//:windows_aarch64_to_linux_x86_64",
+    "@llvm_toolchains//:windows_x86_64_to_linux_aarch64",
+    "@llvm_toolchains//:windows_x86_64_to_linux_x86_64",
     dev_dependency = True,
 )
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,20 @@ Add `linux.bzl` and a hermetic C/C++ toolchain to `MODULE.bazel`:
 bazel_dep(name = "linux.bzl", version = "0.1.0")
 bazel_dep(name = "llvm", version = "0.8.14")
 
-register_toolchains("@llvm//toolchain:all")
+register_toolchains(
+    "@llvm//toolchain:linux_aarch64_to_linux_aarch64",
+    "@llvm//toolchain:linux_aarch64_to_linux_x86_64",
+    "@llvm//toolchain:linux_x86_64_to_linux_aarch64",
+    "@llvm//toolchain:linux_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:macos_aarch64_to_linux_aarch64",
+    "@llvm//toolchain:macos_aarch64_to_linux_x86_64",
+    "@llvm//toolchain:macos_x86_64_to_linux_aarch64",
+    "@llvm//toolchain:macos_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:windows_aarch64_to_linux_aarch64",
+    "@llvm//toolchain:windows_aarch64_to_linux_x86_64",
+    "@llvm//toolchain:windows_x86_64_to_linux_aarch64",
+    "@llvm//toolchain:windows_x86_64_to_linux_x86_64",
+)
 
 linux_source_repository = use_repo_rule(
     "@linux.bzl//:linux.bzl",

--- a/aya_e2e/patches/aya_linux_bzl_api.patch
+++ b/aya_e2e/patches/aya_linux_bzl_api.patch
@@ -30,13 +30,25 @@ index 00d93a2..e591333 100644
  
  # Each qemu-system toolchain is compatible with the corresponding
  # //bazel:bpf_target_arch value. bazel/vm.bzl transitions that value for each
-@@ -74,7 +75,7 @@
+@@ -74,7 +75,18 @@
  
  register_toolchains(
      "@copy_to_directory_toolchains//:all",
 -    "@default_rust_toolchains//:all",
 +    "@aya_rust_toolchains//:all",
-     "@llvm//toolchain:all",
+-    "@llvm//toolchain:all",
++    "@llvm//toolchain:linux_aarch64_to_linux_aarch64",
++    "@llvm//toolchain:linux_aarch64_to_linux_x86_64",
++    "@llvm//toolchain:linux_x86_64_to_linux_aarch64",
++    "@llvm//toolchain:linux_x86_64_to_linux_x86_64",
++    "@llvm//toolchain:macos_aarch64_to_linux_aarch64",
++    "@llvm//toolchain:macos_aarch64_to_linux_x86_64",
++    "@llvm//toolchain:macos_x86_64_to_linux_aarch64",
++    "@llvm//toolchain:macos_x86_64_to_linux_x86_64",
++    "@llvm//toolchain:windows_aarch64_to_linux_aarch64",
++    "@llvm//toolchain:windows_aarch64_to_linux_x86_64",
++    "@llvm//toolchain:windows_x86_64_to_linux_aarch64",
++    "@llvm//toolchain:windows_x86_64_to_linux_x86_64",
      "@qemu_system_toolchains//:all",
  )
 @@ -126,54 +126,34 @@ use_repo(crate, "crates")

--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -11,7 +11,20 @@ bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_go", version = "0.62.0")
 bazel_dep(name = "rules_qemu", version = "0.3.0")
 
-register_toolchains("@hermetic_llvm//toolchain:all")
+register_toolchains(
+    "@hermetic_llvm//toolchain:linux_aarch64_to_linux_aarch64",
+    "@hermetic_llvm//toolchain:linux_aarch64_to_linux_x86_64",
+    "@hermetic_llvm//toolchain:linux_x86_64_to_linux_aarch64",
+    "@hermetic_llvm//toolchain:linux_x86_64_to_linux_x86_64",
+    "@hermetic_llvm//toolchain:macos_aarch64_to_linux_aarch64",
+    "@hermetic_llvm//toolchain:macos_aarch64_to_linux_x86_64",
+    "@hermetic_llvm//toolchain:macos_x86_64_to_linux_aarch64",
+    "@hermetic_llvm//toolchain:macos_x86_64_to_linux_x86_64",
+    "@hermetic_llvm//toolchain:windows_aarch64_to_linux_aarch64",
+    "@hermetic_llvm//toolchain:windows_aarch64_to_linux_x86_64",
+    "@hermetic_llvm//toolchain:windows_x86_64_to_linux_aarch64",
+    "@hermetic_llvm//toolchain:windows_x86_64_to_linux_x86_64",
+)
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.nogo(nogo = "@rules_go//:tools_nogo")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -13,7 +13,23 @@ local_path_override(
     path = "..",
 )
 
-register_toolchains("@llvm//toolchain:all")
+# Register only the host/target pairs used by linux.bzl. The catch-all target
+# also registers every bootstrap stage and unrelated OS/CPU combination, which
+# makes Bazel analyze hundreds of toolchains before reaching the kernel graph.
+register_toolchains(
+    "@llvm//toolchain:linux_aarch64_to_linux_aarch64",
+    "@llvm//toolchain:linux_aarch64_to_linux_x86_64",
+    "@llvm//toolchain:linux_x86_64_to_linux_aarch64",
+    "@llvm//toolchain:linux_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:macos_aarch64_to_linux_aarch64",
+    "@llvm//toolchain:macos_aarch64_to_linux_x86_64",
+    "@llvm//toolchain:macos_x86_64_to_linux_aarch64",
+    "@llvm//toolchain:macos_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:windows_aarch64_to_linux_aarch64",
+    "@llvm//toolchain:windows_aarch64_to_linux_x86_64",
+    "@llvm//toolchain:windows_x86_64_to_linux_aarch64",
+    "@llvm//toolchain:windows_x86_64_to_linux_x86_64",
+)
 
 linux_source_repository = use_repo_rule(
     "@linux.bzl//:linux.bzl",


### PR DESCRIPTION
## Summary

- replace LLVM catch-all toolchain registration with the 12 Linux host/target pairs used by linux.bzl
- give CI analysis enough heap while discarding incremental analysis state after each one-shot invocation
- report analysis time, configured targets, packages, heap, repository generation, and Linux object analysis cost from BEP/profile data
- apply the same registration policy to examples, e2e, and the Aya integration patch

## Root cause

`@llvm//toolchain:all` expands to 1,873 labels, including bootstrap stages and unrelated OS/CPU combinations. Those registrations are analyzed before the kernel graph. The three-kernel CI invocation also retained a large analysis graph despite having no subsequent incremental command in the same server.

## Impact

The explicit registration set contains 12 toolchains. CI profiles now expose the remaining repository and rule-analysis costs directly, and one-shot jobs release analysis state after the command.

## Validation

- `bazel test //:buildifier_test`
- `bazel mod graph --lockfile_mode=error` in `examples`, `e2e`, and `aya_e2e`
- `actionlint .github/workflows/ci.yml .github/workflows/host-platforms.yml`
- `shellcheck .github/workflows/bazel_cache_report.sh`

## Stack

This PR is stacked on #20 because it updates the host-platform workflow introduced there. The content-addressed kernel graph follows in a separate PR.