### PR TITLE
Prepare kconfig v0.0.14 tooling

### DIFF
--- a/KCONFIG_RELEASING.md
+++ b/KCONFIG_RELEASING.md
@@ -13,27 +13,38 @@ requests another schema.
 Schema `v0.0.12` is opt-in. It emits classified source-tree inputs, exact
 source-like include closures, module object roots, and fail-closed source
 actions. Rust-owned objects are excluded from the ordinary object graph.
-`-rust_profile_out` additionally emits the source-derived
-`linux-rust-profile-v1` JSON profile and is valid only with
-`-compact_schema=v0.0.12`.
+`-rust_profile_out` additionally emits a source-derived Rust profile and is
+valid only with `-compact_schema=v0.0.12`.
 
 Generator `v0.0.13` keeps schema `v0.0.12` and adds config-sensitive
 KASAN/KCSAN/UBSAN instrumentation flags, including Kbuild per-object and
 per-directory overrides.
 
+Generator `v0.0.14` keeps compact schema `v0.0.12`, upgrades the separate Rust
+profile to `linux-rust-profile-v2`, and supports both x86_64 and arm64. The
+profile records source-derived rustc version gates and the architecture's
+built-in or generated Rust target specification. `kconfig_parse` also accepts
+the exact selected Rust toolchain probe so action-time config resolution can
+verify that dynamic rustc capabilities do not change the repository-generated
+structural snapshot. Compact object metadata preserves module roots and
+`OBJECT_FILES_NON_STANDARD` overrides, and can carry the source-built x86
+objtool label required for Kbuild-compatible post-processing.
+
 ## Prepare
 
-1. Run `go test ./internal/kconfig ./internal/cmd/kconfig ./internal/cmd/kconfig_parse`.
+1. Run `go test ./internal/kconfig ./internal/rusttoolchain ./internal/cmd/kconfig ./internal/cmd/kconfig_parse`.
 2. Run the Bazel generator, compact-golden, and prebuilt archive tests.
 3. Exercise v0.0.12 against maintained Linux 6.12 and 6.18 source trees with
-   `CONFIG_RUST=y`. Verify that the legacy and pin-init Rust layouts produce
-   valid profiles and that a modified but compatible source tree is accepted.
+   `CONFIG_RUST=y` on x86_64 and arm64. Verify that the legacy and pin-init Rust
+   layouts produce valid v2 profiles, that built-in and generated target
+   specifications are selected correctly, and that a modified but compatible
+   source tree is accepted.
 4. Exercise C sanitizer configs against maintained Linux 6.12 and 6.18 source
    trees. Verify KASAN/KCSAN/UBSAN object opt-outs, test-object opt-ins, arm64
    nVHE defaults, and integer-wrap inputs.
 5. Verify that unsupported source layouts, unresolved Make expressions,
-   incomplete leaf objects, and non-x86_64 Rust profiles fail with actionable
-   errors.
+   incomplete leaf objects, and unsupported Rust architectures fail with
+   actionable errors.
 6. Build the six platform archives twice from clean output trees and compare
    their SHA-256 digests.
 
@@ -47,7 +58,7 @@ version stream.
 After the release-preparation change is merged, tag that merge commit:
 
 ```sh
-VERSION=v0.0.13 ./release_kconfig.sh
+VERSION=v0.0.14 ./release_kconfig.sh
 ```
 
 The tag workflow publishes archives for Linux, macOS, and Windows on amd64 and

--- a/internal/cmd/kconfig_parse/BUILD.bazel
+++ b/internal/cmd/kconfig_parse/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/hermeticbuild/linux.bzl/internal/cmd/kconfig_parse",
     visibility = ["//visibility:private"],
-    deps = ["//internal/kconfig"],
+    deps = [
+        "//internal/kconfig",
+        "//internal/rusttoolchain",
+    ],
 )
 
 go_binary(
@@ -19,5 +22,8 @@ go_test(
     name = "kconfig_parse_test",
     srcs = ["main_test.go"],
     embed = [":kconfig_parse_lib"],
-    deps = ["//internal/kconfig"],
+    deps = [
+        "//internal/kconfig",
+        "//internal/rusttoolchain",
+    ],
 )

--- a/internal/cmd/kconfig_parse/main.go
+++ b/internal/cmd/kconfig_parse/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/hermeticbuild/linux.bzl/internal/kconfig"
+	"github.com/hermeticbuild/linux.bzl/internal/rusttoolchain"
 )
 
 type stringMapFlag map[string]string
@@ -27,6 +28,15 @@ func (f stringMapFlag) Set(value string) error {
 	}
 	f[key] = val
 	return nil
+}
+
+func applyRustToolchainProbe(
+	vars, linuxProbeValues stringMapFlag,
+	probe rusttoolchain.Probe,
+) {
+	vars["RUSTC_VERSION_TEXT"] = probe.VersionText
+	linuxProbeValues["rustc_version"] = strconv.Itoa(probe.VersionCode)
+	linuxProbeValues["rustc_llvm_version"] = strconv.Itoa(probe.LLVMVersionCode)
 }
 
 type stringSliceFlag []string
@@ -117,6 +127,8 @@ func main() {
 		srctree                  = flag.String("srctree", "", "Source tree used to resolve source statements")
 		allowShell               = flag.Bool("allow_shell", false, "Allow $(shell,...) expansion")
 		linuxProbeModel          = flag.String("linux_probe_model", "", "Hermetic Linux Kconfig probe model to use for $(shell,...) expansion. Supported: linux_llvm")
+		rustToolchainProbe       = flag.String("rust_toolchain_probe", "", "JSON identity produced from the selected rustc -vV output")
+		validateConfigEquivalent = flag.Bool("validate_config_equivalence", false, "Require action-time config to match the repository-generated structural snapshot")
 		out                      = flag.String("out", "", "Path to write the parsed Kconfig as JSON. Defaults to stdout when no other output is set")
 		kbuildPath               = flag.String("kbuild", "", "Kbuild/Makefile path for compact object metadata generation")
 		kbuildRecursive          = flag.Bool("kbuild_recursive", false, "Follow static Kbuild include directives when writing -kbuild_out")
@@ -148,6 +160,7 @@ func main() {
 		objectLabelPackage       = flag.String("object_label_package", "", "Bazel package containing the compact object BUILD file. Defaults to -object_buildfile_out package")
 		sourceLabelPackage       = flag.String("source_label_package", "", "Bazel package containing Linux source file labels for generated compact object BUILD files")
 		sourceASN1Compiler       = flag.String("source_asn1_compiler", "", "Bazel label for the kernel source tree's scripts/asn1_compiler tool emitted into source-backed compact object rules")
+		sourceObjtool            = flag.String("source_objtool", "", "Bazel label for the kernel source tree's objtool executable emitted into x86 source-backed compact object rules")
 		sourceRelacheck          = flag.String("source_relacheck", "", "Bazel label for the kernel source tree's arch/arm64/kernel/pi/relacheck tool emitted into arm64 .pi.o rules")
 		sourceConfig             = flag.String("source_config", "", "Bazel label for a full LinuxConfigInfo target emitted into source-backed compact object rules")
 		sourceRootLabel          = flag.String("source_root_label", "", "Bazel label for a file in the Linux source root, emitted into source-backed compact object rules")
@@ -213,6 +226,24 @@ func main() {
 	var tree *kconfig.Tree
 	if *root != "" {
 		var err error
+		if *rustToolchainProbe != "" {
+			probeFile, openErr := os.Open(workspacePath(*rustToolchainProbe))
+			if openErr != nil {
+				fmt.Fprintf(os.Stderr, "failed to open Rust toolchain probe: %v\n", openErr)
+				os.Exit(1)
+			}
+			probe, decodeErr := rusttoolchain.Decode(probeFile)
+			closeErr := probeFile.Close()
+			if decodeErr != nil {
+				fmt.Fprintf(os.Stderr, "failed to decode Rust toolchain probe: %v\n", decodeErr)
+				os.Exit(1)
+			}
+			if closeErr != nil {
+				fmt.Fprintf(os.Stderr, "failed to close Rust toolchain probe: %v\n", closeErr)
+				os.Exit(1)
+			}
+			applyRustToolchainProbe(vars, linuxProbeValues, probe)
+		}
 		shell, err := linuxProbeShell(*linuxProbeModel, linuxProbeValues)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to configure Linux probe model: %v\n", err)
@@ -342,7 +373,7 @@ func main() {
 			autoconf:      *resolvedAutoconfOut,
 			rustcCfg:      *resolvedRustcCfgOut,
 			kernelRelease: *resolvedReleaseOut,
-		}, *kernelVersion); err != nil {
+		}, *kernelVersion, *validateConfigEquivalent); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write resolved config: %v\n", err)
 			os.Exit(1)
 		}
@@ -381,6 +412,7 @@ func main() {
 				SourceLabelPackage:       *sourceLabelPackage,
 				SourceLabelPackages:      namedValueMap(sourceLabelMaps),
 				SourceASN1Compiler:       *sourceASN1Compiler,
+				SourceObjtool:            *sourceObjtool,
 				SourceRelacheck:          *sourceRelacheck,
 				SourceConfig:             *sourceConfig,
 				SourceRootLabel:          *sourceRootLabel,
@@ -437,6 +469,7 @@ func main() {
 				SourceLabelPackage:       *sourceLabelPackage,
 				SourceLabelPackages:      namedValueMap(sourceLabelMaps),
 				SourceASN1Compiler:       *sourceASN1Compiler,
+				SourceObjtool:            *sourceObjtool,
 				SourceRelacheck:          *sourceRelacheck,
 				SourceConfig:             *sourceConfig,
 				SourceRootLabel:          *sourceRootLabel,
@@ -548,7 +581,7 @@ type resolvedConfigOutputs struct {
 	kernelRelease string
 }
 
-func writeResolvedConfig(tree *kconfig.Tree, input, overlay, configMode string, outputs resolvedConfigOutputs, kernelVersion string) error {
+func writeResolvedConfig(tree *kconfig.Tree, input, overlay, configMode string, outputs resolvedConfigOutputs, kernelVersion string, validateEquivalent bool) error {
 	if input == "" {
 		return fmt.Errorf("-resolve_config is required when resolved config outputs are requested")
 	}
@@ -594,6 +627,11 @@ func writeResolvedConfig(tree *kconfig.Tree, input, overlay, configMode string, 
 	resolved, err := tree.ResolveConfigWithOptions(name, raw, resolveOpts)
 	if err != nil {
 		return err
+	}
+	if validateEquivalent {
+		if err := kconfig.ValidateRustToolchainEquivalence(raw, resolved); err != nil {
+			return err
+		}
 	}
 	return writeResolvedConfigOutputs(tree, resolved, outputs, kernelVersion)
 }

--- a/internal/cmd/kconfig_parse/main_test.go
+++ b/internal/cmd/kconfig_parse/main_test.go
@@ -5,7 +5,27 @@ import (
 	"testing"
 
 	"github.com/hermeticbuild/linux.bzl/internal/kconfig"
+	"github.com/hermeticbuild/linux.bzl/internal/rusttoolchain"
 )
+
+func TestApplyRustToolchainProbe(t *testing.T) {
+	vars := stringMapFlag{"RUSTC_VERSION_TEXT": "repository baseline"}
+	probeValues := stringMapFlag{}
+	applyRustToolchainProbe(vars, probeValues, rusttoolchain.Probe{
+		VersionText:     "rustc 1.98.0-nightly (012345678 2026-06-24)",
+		VersionCode:     109800,
+		LLVMVersionCode: 220107,
+	})
+	if got, want := vars["RUSTC_VERSION_TEXT"], "rustc 1.98.0-nightly (012345678 2026-06-24)"; got != want {
+		t.Fatalf("RUSTC_VERSION_TEXT = %q, want %q", got, want)
+	}
+	if got, want := probeValues["rustc_version"], "109800"; got != want {
+		t.Fatalf("rustc_version = %q, want %q", got, want)
+	}
+	if got, want := probeValues["rustc_llvm_version"], "220107"; got != want {
+		t.Fatalf("rustc_llvm_version = %q, want %q", got, want)
+	}
+}
 
 func TestKbuildVariablesForConfigUsesWrittenConfigView(t *testing.T) {
 	vars := kbuildVariablesForConfig(

--- a/internal/kconfig/compact.go
+++ b/internal/kconfig/compact.go
@@ -54,18 +54,22 @@ type CompactConfig struct {
 }
 
 type CompactObjectVariant struct {
-	Target         string            `json:"target"`
-	Package        string            `json:"package,omitempty"`
-	Object         string            `json:"object"`
-	Source         string            `json:"source,omitempty"`
-	SourceIncludes []string          `json:"source_includes,omitempty"`
-	Mode           string            `json:"mode"`
-	ModName        string            `json:"modname,omitempty"`
-	Flags          []string          `json:"flags,omitempty"`
-	RemoveFlags    []string          `json:"remove_flags,omitempty"`
-	ConfigFragment map[string]string `json:"config_fragment,omitempty"`
-	Deps           []string          `json:"deps,omitempty"`
-	Members        []string          `json:"members,omitempty"`
+	Target          string            `json:"target"`
+	Package         string            `json:"package,omitempty"`
+	Object          string            `json:"object"`
+	Source          string            `json:"source,omitempty"`
+	SourceIncludes  []string          `json:"source_includes,omitempty"`
+	Mode            string            `json:"mode"`
+	ModuleRoot      bool              `json:"module_root,omitempty"`
+	ModName         string            `json:"modname,omitempty"`
+	Flags           []string          `json:"flags,omitempty"`
+	RemoveFlags     []string          `json:"remove_flags,omitempty"`
+	ObjtoolArgs     []string          `json:"objtool_args,omitempty"`
+	ObjtoolDisabled bool              `json:"objtool_disabled,omitempty"`
+	ObjtoolForce    bool              `json:"objtool_force,omitempty"`
+	ConfigFragment  map[string]string `json:"config_fragment,omitempty"`
+	Deps            []string          `json:"deps,omitempty"`
+	Members         []string          `json:"members,omitempty"`
 }
 
 type CompactObjectPackage struct {
@@ -81,6 +85,7 @@ type CompactBuildFileOptions struct {
 	SourceLabelPackage       string
 	SourceLabelPackages      map[string]string
 	SourceASN1Compiler       string
+	SourceObjtool            string
 	SourceRelacheck          string
 	SourceRootLabel          string
 	SourceTreeAllFiles       []string
@@ -367,7 +372,7 @@ func cleanKbuildDir(dir string) string {
 }
 
 func (v CompactObjectVariant) equal(other CompactObjectVariant) bool {
-	if v.Target != other.Target || v.Package != other.Package || v.Object != other.Object || v.Source != other.Source || v.Mode != other.Mode || v.ModName != other.ModName || len(v.SourceIncludes) != len(other.SourceIncludes) || len(v.Flags) != len(other.Flags) || len(v.RemoveFlags) != len(other.RemoveFlags) || len(v.ConfigFragment) != len(other.ConfigFragment) || len(v.Deps) != len(other.Deps) || len(v.Members) != len(other.Members) {
+	if v.Target != other.Target || v.Package != other.Package || v.Object != other.Object || v.Source != other.Source || v.Mode != other.Mode || v.ModuleRoot != other.ModuleRoot || v.ModName != other.ModName || v.ObjtoolDisabled != other.ObjtoolDisabled || v.ObjtoolForce != other.ObjtoolForce || len(v.SourceIncludes) != len(other.SourceIncludes) || len(v.Flags) != len(other.Flags) || len(v.RemoveFlags) != len(other.RemoveFlags) || len(v.ObjtoolArgs) != len(other.ObjtoolArgs) || len(v.ConfigFragment) != len(other.ConfigFragment) || len(v.Deps) != len(other.Deps) || len(v.Members) != len(other.Members) {
 		return false
 	}
 	for i := range v.SourceIncludes {
@@ -382,6 +387,11 @@ func (v CompactObjectVariant) equal(other CompactObjectVariant) bool {
 	}
 	for i := range v.RemoveFlags {
 		if v.RemoveFlags[i] != other.RemoveFlags[i] {
+			return false
+		}
+	}
+	for i := range v.ObjtoolArgs {
+		if v.ObjtoolArgs[i] != other.ObjtoolArgs[i] {
 			return false
 		}
 	}
@@ -464,15 +474,18 @@ func compactShortStringArrays(data []byte, printWidth int) []byte {
 }
 
 type resolvedKbuildObject struct {
-	object    string
-	directory string
-	mode      string
-	modname   string
-	flags     []resolvedKbuildFlag
-	remove    []resolvedKbuildFlag
-	footprint map[string]bool
-	members   []string
-	root      bool
+	object          string
+	directory       string
+	mode            string
+	modname         string
+	flags           []resolvedKbuildFlag
+	remove          []resolvedKbuildFlag
+	objtoolArgs     []string
+	objtoolDisabled bool
+	objtoolForce    bool
+	footprint       map[string]bool
+	members         []string
+	root            bool
 }
 
 type resolvedKbuildFlag struct {
@@ -613,6 +626,7 @@ func (kb *KbuildFile) resolvedObjects(config *ResolvedConfig) resolvedKbuildObje
 			}
 		}
 		object.flags = append(object.flags, sanitizerKbuildFlags(config, kb.objectSettings, object)...)
+		object.objtoolDisabled, object.objtoolForce, object.objtoolArgs = kbuildObjtoolSettings(kb, object)
 	}
 
 	out := resolvedKbuildObjects{
@@ -629,6 +643,113 @@ func (kb *KbuildFile) resolvedObjects(config *ResolvedConfig) resolvedKbuildObje
 		}
 	}
 	return out
+}
+
+func kbuildObjtoolSettings(kb *KbuildFile, object *resolvedKbuildObject) (disabled, force bool, args []string) {
+	compileObject := kbuildCompileObjectName(object.object)
+	settingsObject := object
+	if compileObject != object.object {
+		settingsObject = &resolvedKbuildObject{
+			object:    compileObject,
+			directory: object.directory,
+		}
+	}
+	objectValue, directoryValue := kbuildObjectSettingValues(
+		kb.objectSettings,
+		settingsObject,
+		"OBJECT_FILES_NON_STANDARD",
+	)
+	nonStandardValue, hasNonStandardValue := kbuildTargetVariableValue(
+		kb.TargetVariables,
+		compileObject,
+		"OBJECT_FILES_NON_STANDARD",
+	)
+	nonStandard := firstKbuildSettingEnabled(
+		false,
+		conditionalSettingValue(nonStandardValue, hasNonStandardValue),
+		objectValue,
+		directoryValue,
+	)
+	enabledValue, hasEnabledValue := kbuildTargetVariableValue(
+		kb.TargetVariables,
+		compileObject,
+		"objtool-enabled",
+	)
+	enabled := !nonStandard && compileObject == object.object
+	if hasEnabledValue {
+		enabled = strings.TrimSpace(enabledValue) != ""
+		force = enabled
+	}
+	argsValue, hasArgsValue := kbuildTargetVariableValue(
+		kb.TargetVariables,
+		compileObject,
+		"objtool-args",
+	)
+	if hasArgsValue {
+		args = concreteKbuildFlags(kbuildFields(argsValue))
+	}
+	return !enabled, force, args
+}
+
+func conditionalSettingValue(value string, present bool) string {
+	if !present {
+		return ""
+	}
+	if strings.TrimSpace(value) == "" {
+		return "n"
+	}
+	return value
+}
+
+func kbuildCompileObjectName(object string) string {
+	for _, suffix := range []string{".pi.o", ".stub.o"} {
+		if strings.HasSuffix(object, suffix) {
+			return strings.TrimSuffix(object, suffix) + ".o"
+		}
+	}
+	return object
+}
+
+func kbuildTargetVariableValue(variables []KbuildTargetVariable, object, name string) (string, bool) {
+	value := ""
+	assigned := false
+	for _, variable := range variables {
+		if variable.Variable != name || !kbuildTargetVariableMatches(variable.Targets, object) {
+			continue
+		}
+		switch variable.Operator {
+		case "+=":
+			value = appendMakeValue(value, variable.Value)
+			assigned = true
+		case "?=":
+			if !assigned {
+				value = variable.Value
+				assigned = true
+			}
+		default:
+			value = variable.Value
+			assigned = true
+		}
+	}
+	return strings.TrimSpace(value), assigned
+}
+
+func kbuildTargetVariableMatches(targets []string, object string) bool {
+	object = filepath.ToSlash(strings.TrimPrefix(object, "./"))
+	for _, target := range targets {
+		target = filepath.ToSlash(strings.TrimPrefix(target, "./"))
+		prefix, suffix, pattern := strings.Cut(target, "%")
+		if !pattern && target == object {
+			return true
+		}
+		if pattern &&
+			len(object) >= len(prefix)+len(suffix) &&
+			strings.HasPrefix(object, prefix) &&
+			strings.HasSuffix(object, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (kb *KbuildFile) resolvedObjectEntries(config *ResolvedConfig) []KbuildObject {
@@ -972,20 +1093,38 @@ func (o resolvedKbuildObject) variant(config *ResolvedConfig, source string, sou
 	}
 	flags := normalizeSourceRootFlags(filterResolvedKbuildFlags(o.flags, source), sourceRoot)
 	remove := normalizeSourceRootFlags(filterResolvedKbuildFlags(o.remove, source), sourceRoot)
-	hash := objectVariantHash(o.object, o.mode, o.modname, flags, remove, fragment, sourceIncludes, deps, members)
+	hash := objectVariantHash(
+		o.object,
+		o.mode,
+		o.modname,
+		flags,
+		remove,
+		fragment,
+		sourceIncludes,
+		deps,
+		members,
+		o.root && o.mode == "m",
+		o.objtoolDisabled,
+		o.objtoolForce,
+		o.objtoolArgs,
+	)
 	return CompactObjectVariant{
-		Target:         sanitizeTargetName(strings.TrimSuffix(o.object, ".o")) + "__" + hash,
-		Package:        objectPackage(o.object),
-		Object:         o.object,
-		Source:         source,
-		SourceIncludes: append([]string(nil), sourceIncludes...),
-		Mode:           o.mode,
-		ModName:        o.modname,
-		Flags:          flags,
-		RemoveFlags:    remove,
-		ConfigFragment: fragment,
-		Deps:           append([]string(nil), deps...),
-		Members:        append([]string(nil), members...),
+		Target:          sanitizeTargetName(strings.TrimSuffix(o.object, ".o")) + "__" + hash,
+		Package:         objectPackage(o.object),
+		Object:          o.object,
+		Source:          source,
+		SourceIncludes:  append([]string(nil), sourceIncludes...),
+		Mode:            o.mode,
+		ModuleRoot:      o.root && o.mode == "m",
+		ModName:         o.modname,
+		Flags:           flags,
+		RemoveFlags:     remove,
+		ObjtoolArgs:     append([]string(nil), o.objtoolArgs...),
+		ObjtoolDisabled: o.objtoolDisabled,
+		ObjtoolForce:    o.objtoolForce,
+		ConfigFragment:  fragment,
+		Deps:            append([]string(nil), deps...),
+		Members:         append([]string(nil), members...),
 	}
 }
 
@@ -1243,7 +1382,7 @@ func objectPackage(object string) string {
 	return dir
 }
 
-func objectVariantHash(object, mode, modname string, flags, removeFlags []string, fragment map[string]string, sourceIncludes, deps, members []string) string {
+func objectVariantHash(object, mode, modname string, flags, removeFlags []string, fragment map[string]string, sourceIncludes, deps, members []string, moduleRoot, objtoolDisabled, objtoolForce bool, objtoolArgs []string) string {
 	var b strings.Builder
 	b.WriteString(object)
 	b.WriteByte('\n')
@@ -1258,6 +1397,20 @@ func objectVariantHash(object, mode, modname string, flags, removeFlags []string
 	for _, flag := range removeFlags {
 		b.WriteString("remove=")
 		b.WriteString(flag)
+		b.WriteByte('\n')
+	}
+	if moduleRoot {
+		b.WriteString("module_root=true\n")
+	}
+	if objtoolDisabled {
+		b.WriteString("objtool=disabled\n")
+	}
+	if objtoolForce {
+		b.WriteString("objtool=force\n")
+	}
+	for _, arg := range objtoolArgs {
+		b.WriteString("objtool_arg=")
+		b.WriteString(arg)
 		b.WriteByte('\n')
 	}
 	for _, key := range sortedConfigKeys(fragment) {
@@ -1379,6 +1532,15 @@ func (m *CompactMetadata) ObjectBuildFile(opts CompactBuildFileOptions) ([]byte,
 			r.SetAttr("mode", variant.Mode)
 			r.SetAttr("tags", []string{"manual"})
 			r.SetAttr("objects", localLabels(variant.Members))
+			if variant.ModuleRoot {
+				r.SetAttr("module_root", true)
+			}
+			if variant.ObjtoolForce {
+				r.SetAttr("objtool_force", true)
+			}
+			if len(variant.ObjtoolArgs) != 0 {
+				r.SetAttr("objtool_args", variant.ObjtoolArgs)
+			}
 			if opts.Arch != "" {
 				r.SetAttr("arch", opts.Arch)
 			}
@@ -1458,9 +1620,21 @@ func (m *CompactMetadata) ObjectBuildFile(opts CompactBuildFileOptions) ([]byte,
 			if opts.SourceASN1Compiler != "" && strings.HasSuffix(variant.Object, ".asn1.o") {
 				r.SetAttr("asn1_compiler", opts.SourceASN1Compiler)
 			}
+			if opts.Arch == "x86" && opts.SourceObjtool != "" && !variant.ObjtoolDisabled {
+				r.SetAttr("objtool", opts.SourceObjtool)
+				if variant.ObjtoolForce {
+					r.SetAttr("objtool_force", true)
+				}
+				if len(variant.ObjtoolArgs) != 0 {
+					r.SetAttr("objtool_args", variant.ObjtoolArgs)
+				}
+			}
 			if opts.SourceRelacheck != "" && strings.HasSuffix(variant.Object, ".pi.o") {
 				r.SetAttr("relacheck", opts.SourceRelacheck)
 			}
+		}
+		if variant.ModuleRoot {
+			r.SetAttr("module_root", true)
 		}
 		if len(variant.Flags) != 0 {
 			r.SetAttr("flags", variant.Flags)

--- a/internal/kconfig/compact_test.go
+++ b/internal/kconfig/compact_test.go
@@ -412,6 +412,178 @@ obj-y := $(patsubst %.o,%.pi.o,$(obj-y))
 	}
 }
 
+func TestCompactMetadataPreservesObjtoolSettings(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	kb, err := parseKbuild(strings.NewReader(`obj-y += startup.o
+pi-objs := $(patsubst %.o,$(obj)/%.o,$(obj-y))
+$(pi-objs): objtool-enabled = 1
+$(pi-objs): objtool-args = $(if $(delay-objtool),,$(objtool-args-y)) --noabs
+targets += $(obj-y)
+obj-y := $(patsubst %.o,%.pi.o,$(obj-y))
+obj-y += normal.o head.o ignored.pi.o efi.stub.o
+obj-m += module.o
+OBJECT_FILES_NON_STANDARD := y
+OBJECT_FILES_NON_STANDARD_normal.o := n
+OBJECT_FILES_NON_STANDARD_ignored.o := y
+OBJECT_FILES_NON_STANDARD_efi.o := n
+`), "Kbuild", map[string]string{"obj": "."}, "")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	sourceRoot := t.TempDir()
+	for _, source := range []string{"normal.c", "head.c", "ignored.c", "efi.c", "startup.c", "module.c"} {
+		writeCompactSource(t, sourceRoot, source)
+	}
+	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{{Name: "base"}}, CompactMetadataOptions{
+		Schema:     CompactSchemaV012,
+		SourceRoot: sourceRoot,
+	})
+	if err != nil {
+		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+	}
+	config := configByName(metadata, "base")
+	normal := variantByTarget(metadata, objectTarget(metadata, config, "normal.o"))
+	head := variantByTarget(metadata, objectTarget(metadata, config, "head.o"))
+	ignored := variantByTarget(metadata, objectTarget(metadata, config, "ignored.pi.o"))
+	efi := variantByTarget(metadata, objectTarget(metadata, config, "efi.stub.o"))
+	startup := variantByTarget(metadata, objectTarget(metadata, config, "startup.pi.o"))
+	module := variantByTarget(metadata, moduleObjectTarget(metadata, config, "module.o"))
+	if normal.ObjtoolDisabled {
+		t.Fatal("normal.o did not preserve its per-object override of the directory setting")
+	}
+	if !head.ObjtoolDisabled {
+		t.Fatal("head.o did not preserve directory OBJECT_FILES_NON_STANDARD")
+	}
+	if !ignored.ObjtoolDisabled {
+		t.Fatal("ignored.pi.o did not inherit OBJECT_FILES_NON_STANDARD_ignored.o")
+	}
+	if !efi.ObjtoolDisabled {
+		t.Fatal("efi.stub.o unexpectedly enabled objtool for its rewritten underlying efi.o")
+	}
+	if startup.ObjtoolDisabled || !startup.ObjtoolForce || !reflect.DeepEqual(startup.ObjtoolArgs, []string{"--noabs"}) {
+		t.Fatalf("startup.pi.o objtool settings = disabled:%t force:%t args:%q", startup.ObjtoolDisabled, startup.ObjtoolForce, startup.ObjtoolArgs)
+	}
+
+	objectBuild, err := metadata.ObjectBuildFile(CompactBuildFileOptions{
+		Schema:             CompactSchemaV012,
+		Arch:               "x86",
+		SourceLabelPackage: "@linux//",
+		SourceObjtool:      "//linux:objtool",
+		SourceRootLabel:    "@linux//:Kconfig",
+	})
+	if err != nil {
+		t.Fatalf("ObjectBuildFile() failed: %v", err)
+	}
+	parsed, err := build.ParseBuild("objects.BUILD.bazel", objectBuild)
+	if err != nil {
+		t.Fatalf("generated object BUILD did not parse: %v\n%s", err, objectBuild)
+	}
+	if got := parsed.RuleNamed(head.Target).AttrString("objtool"); got != "" {
+		t.Fatalf("head.o objtool = %q, want omitted", got)
+	}
+	if got := parsed.RuleNamed(normal.Target).AttrString("objtool"); got != "//linux:objtool" {
+		t.Fatalf("normal.o objtool = %q, want //linux:objtool", got)
+	}
+	if got := parsed.RuleNamed(module.Target).AttrString("objtool"); got != "" {
+		t.Fatalf("module.o objtool = %q, want module-root processing only", got)
+	}
+	if !module.ModuleRoot || parsed.RuleNamed(module.Target).AttrLiteral("module_root") != "True" {
+		t.Fatalf("module.o did not preserve its single-module root marker")
+	}
+	if got := parsed.RuleNamed(startup.Target).AttrStrings("objtool_args"); !reflect.DeepEqual(got, []string{"--noabs"}) {
+		t.Fatalf("startup.pi.o objtool_args = %q, want [--noabs]", got)
+	}
+	if !strings.Contains(string(objectBuild), "objtool_force = True") {
+		t.Fatalf("startup.pi.o BUILD rule is missing objtool_force:\n%s", objectBuild)
+	}
+}
+
+func TestCompactMetadataPreservesModuleObjtoolShape(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	kb, err := ParseKbuild(strings.NewReader(`obj-m += single.o multi.o
+multi-y := member.o skipped.o forced.o
+OBJECT_FILES_NON_STANDARD_skipped.o := y
+forced.o: objtool-enabled = 1
+forced.o: objtool-args = --custom
+`), "Kbuild")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	sourceRoot := t.TempDir()
+	for _, source := range []string{"single.c", "member.c", "skipped.c", "forced.c"} {
+		writeCompactSource(t, sourceRoot, source)
+	}
+	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{{Name: "base"}}, CompactMetadataOptions{
+		Schema:     CompactSchemaV012,
+		SourceRoot: sourceRoot,
+	})
+	if err != nil {
+		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+	}
+	config := configByName(metadata, "base")
+	single := variantByTarget(metadata, moduleObjectTarget(metadata, config, "single.o"))
+	multi := variantByTarget(metadata, moduleObjectTarget(metadata, config, "multi.o"))
+	members := map[string]CompactObjectVariant{}
+	for _, target := range multi.Members {
+		variant := variantByTarget(metadata, target)
+		members[variant.Object] = variant
+	}
+	member := members["member.o"]
+	skipped := members["skipped.o"]
+	forced := members["forced.o"]
+	if !single.ModuleRoot || len(single.Members) != 0 || single.ObjtoolDisabled {
+		t.Fatalf("single.o metadata = root:%t members:%q disabled:%t", single.ModuleRoot, single.Members, single.ObjtoolDisabled)
+	}
+	if !multi.ModuleRoot || len(multi.Members) != 3 {
+		t.Fatalf("multi.o metadata = root:%t members:%q", multi.ModuleRoot, multi.Members)
+	}
+	if member.ModuleRoot || member.ObjtoolDisabled {
+		t.Fatalf("member.o metadata = root:%t disabled:%t", member.ModuleRoot, member.ObjtoolDisabled)
+	}
+	if !skipped.ObjtoolDisabled {
+		t.Fatal("skipped.o did not preserve OBJECT_FILES_NON_STANDARD")
+	}
+	if !forced.ObjtoolForce || !reflect.DeepEqual(forced.ObjtoolArgs, []string{"--custom"}) {
+		t.Fatalf("forced.o objtool metadata = force:%t args:%q", forced.ObjtoolForce, forced.ObjtoolArgs)
+	}
+
+	objectBuild, err := metadata.ObjectBuildFile(CompactBuildFileOptions{
+		Schema:             CompactSchemaV012,
+		Arch:               "x86",
+		SourceLabelPackage: "@linux//",
+		SourceObjtool:      "//linux:objtool",
+		SourceRootLabel:    "@linux//:Kconfig",
+	})
+	if err != nil {
+		t.Fatalf("ObjectBuildFile() failed: %v", err)
+	}
+	parsed, err := build.ParseBuild("objects.BUILD.bazel", objectBuild)
+	if err != nil {
+		t.Fatalf("generated object BUILD did not parse: %v\n%s", err, objectBuild)
+	}
+	singleRule := parsed.RuleNamed(single.Target)
+	if singleRule.Kind() != "linux_object" ||
+		singleRule.AttrLiteral("module_root") != "True" ||
+		singleRule.AttrString("objtool") != "//linux:objtool" {
+		t.Fatalf("single.o rule does not carry single-module objtool metadata:\n%s", objectBuild)
+	}
+	multiRule := parsed.RuleNamed(multi.Target)
+	if multiRule.Kind() != "linux_composite_object" || multiRule.AttrLiteral("module_root") != "True" {
+		t.Fatalf("multi.o rule does not carry composite-module metadata:\n%s", objectBuild)
+	}
+	if got := parsed.RuleNamed(member.Target).AttrString("objtool"); got != "//linux:objtool" {
+		t.Fatalf("member.o objtool = %q, want //linux:objtool", got)
+	}
+	if got := parsed.RuleNamed(skipped.Target).AttrString("objtool"); got != "" {
+		t.Fatalf("skipped.o objtool = %q, want omitted", got)
+	}
+	forcedRule := parsed.RuleNamed(forced.Target)
+	if forcedRule.AttrLiteral("objtool_force") != "True" ||
+		!reflect.DeepEqual(forcedRule.AttrStrings("objtool_args"), []string{"--custom"}) {
+		t.Fatalf("forced.o rule does not preserve custom objtool settings:\n%s", objectBuild)
+	}
+}
+
 func TestCompactMetadataPreservesKbuildRootOrder(t *testing.T) {
 	tree := mustParseCompactFixture(t)
 	kb, err := ParseKbuild(strings.NewReader(`obj-y += z.o
@@ -1052,6 +1224,7 @@ func TestCompactObjectBuildFileEmitsSourceLabels(t *testing.T) {
 		Schema:             CompactSchemaV012,
 		Arch:               "x86",
 		SourceLabelPackage: "@linux//",
+		SourceObjtool:      "//linux:objtool",
 		SourceRootLabel:    "@linux//:Kconfig",
 	})
 	if err != nil {
@@ -1074,12 +1247,41 @@ func TestCompactObjectBuildFileEmitsSourceLabels(t *testing.T) {
 		`source_tree_info = ":_source_tree"`,
 		`name = "` + initTarget + `_config"`,
 		`config = ":` + initTarget + `_config"`,
+		`objtool = "//linux:objtool"`,
 		`src = "@linux//:subdir/init.c"`,
 		`src = "@linux//:subdir/net/core.c"`,
 	} {
 		if !strings.Contains(string(objectBuild), want) {
 			t.Fatalf("object BUILD missing %s:\n%s", want, objectBuild)
 		}
+	}
+}
+
+func TestCompactObjectBuildFileLimitsSourceObjtoolToX86(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	kb := mustParseKbuildFixture(t)
+	sourceRoot := t.TempDir()
+	writeCompactSource(t, sourceRoot, "subdir/init.c")
+	writeCompactSource(t, sourceRoot, "subdir/net/core.c")
+
+	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
+		{Name: "base", Flags: map[string]string{"CONFIG_NET": "y"}},
+	}, CompactMetadataOptions{Schema: CompactSchemaV012, ObjectDir: "subdir", SourceRoot: sourceRoot})
+	if err != nil {
+		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+	}
+	objectBuild, err := metadata.ObjectBuildFile(CompactBuildFileOptions{
+		Schema:             CompactSchemaV012,
+		Arch:               "arm64",
+		SourceLabelPackage: "@linux//",
+		SourceObjtool:      "//linux:objtool",
+		SourceRootLabel:    "@linux//:Kconfig",
+	})
+	if err != nil {
+		t.Fatalf("ObjectBuildFile() failed: %v", err)
+	}
+	if strings.Contains(string(objectBuild), `objtool = "//linux:objtool"`) {
+		t.Fatalf("arm64 object BUILD unexpectedly contains x86 objtool:\n%s", objectBuild)
 	}
 }
 

--- a/internal/kconfig/config.go
+++ b/internal/kconfig/config.go
@@ -176,6 +176,7 @@ func (t *Tree) ResolveConfig(name string, raw map[string]string) (*ResolvedConfi
 // ResolveConfigWithOptions computes effective Kconfig values for one imported
 // .config with explicit resolver semantics.
 func (t *Tree) ResolveConfigWithOptions(name string, raw map[string]string, opts ResolveConfigOptions) (*ResolvedConfig, error) {
+	raw = WithoutRustToolchainValues(raw)
 	resolver := &configResolver{
 		tree:        t,
 		rawFlags:    raw,
@@ -253,6 +254,62 @@ func (t *Tree) ResolveConfigWithOptions(name string, raw map[string]string, opts
 		}
 	}
 	return nil, fmt.Errorf("effective Kconfig values did not converge")
+}
+
+// IsRustToolchainValue reports hidden Kconfig values that must be derived from
+// the rustc selected by Bazel, never imported from a checked-in fragment.
+func IsRustToolchainValue(key string) bool {
+	switch key {
+	case "CONFIG_RUSTC_VERSION",
+		"CONFIG_RUSTC_LLVM_VERSION",
+		"CONFIG_RUSTC_VERSION_TEXT",
+		"CONFIG_RUST_IS_AVAILABLE",
+		"CONFIG_HAVE_CFI_ICALL_NORMALIZE_INTEGERS_RUSTC":
+		return true
+	default:
+		return strings.HasPrefix(key, "CONFIG_RUSTC_HAS_")
+	}
+}
+
+// WithoutRustToolchainValues returns a copy with toolchain-owned values
+// removed. Kconfig then obtains them exclusively from its hermetic probe model.
+func WithoutRustToolchainValues(flags map[string]string) map[string]string {
+	filtered := make(map[string]string, len(flags))
+	for key, value := range flags {
+		if !IsRustToolchainValue(key) {
+			filtered[key] = value
+		}
+	}
+	return filtered
+}
+
+// ValidateRustToolchainEquivalence ensures action-time toolchain probing did
+// not change the repository-generated structural Kconfig snapshot. Dynamic
+// Rust toolchain symbols are intentionally ignored.
+func ValidateRustToolchainEquivalence(expected map[string]string, actual *ResolvedConfig) error {
+	expected = WithoutRustToolchainValues(expected)
+	var differences []string
+	for key, want := range expected {
+		if got := actual.Value(key); got != want {
+			differences = append(differences, fmt.Sprintf("%s=%s (generated %s)", key, got, want))
+		}
+	}
+	for key, got := range actual.Effective {
+		if IsRustToolchainValue(key) || !actual.ShouldWrite(key) || got == "" || got == "n" {
+			continue
+		}
+		if _, ok := expected[key]; !ok {
+			differences = append(differences, fmt.Sprintf("%s=%s (absent from generated snapshot)", key, got))
+		}
+	}
+	if len(differences) == 0 {
+		return nil
+	}
+	slices.Sort(differences)
+	if len(differences) > 20 {
+		differences = append(differences[:20], fmt.Sprintf("... and %d more", len(differences)-20))
+	}
+	return fmt.Errorf("selected Rust toolchain changes structural Kconfig values:\n  %s", strings.Join(differences, "\n  "))
 }
 
 type configResolver struct {

--- a/internal/kconfig/config_test.go
+++ b/internal/kconfig/config_test.go
@@ -31,6 +31,59 @@ config TARGET
 	})
 }
 
+func TestResolveConfigIgnoresImportedRustToolchainValues(t *testing.T) {
+	resolved := mustResolveConfig(t, `
+config RUSTC_VERSION
+	int
+	default 109800
+
+config RUSTC_HAS_FOO
+	bool
+	default y
+`, map[string]string{
+		"CONFIG_RUSTC_VERSION": "107800",
+		"CONFIG_RUSTC_HAS_FOO": "n",
+	})
+	if got := resolved.Value("CONFIG_RUSTC_VERSION"); got != "109800" {
+		t.Fatalf("CONFIG_RUSTC_VERSION = %q, want probe-derived default", got)
+	}
+	if got := resolved.Value("CONFIG_RUSTC_HAS_FOO"); got != "y" {
+		t.Fatalf("CONFIG_RUSTC_HAS_FOO = %q, want probe-derived default", got)
+	}
+	if len(resolved.Raw) != 0 {
+		t.Fatalf("raw toolchain values were retained: %#v", resolved.Raw)
+	}
+}
+
+func TestValidateRustToolchainEquivalence(t *testing.T) {
+	actual := &ResolvedConfig{
+		Effective: map[string]string{
+			"CONFIG_RUST":          "y",
+			"CONFIG_RUSTC_VERSION": "109800",
+			"CONFIG_RUSTC_HAS_FOO": "y",
+			"CONFIG_HAVE_CFI_ICALL_NORMALIZE_INTEGERS_RUSTC": "y",
+			"CONFIG_STRUCTURAL_NEW":                          "n",
+		},
+		Written: map[string]bool{
+			"CONFIG_RUST":          true,
+			"CONFIG_RUSTC_VERSION": true,
+			"CONFIG_RUSTC_HAS_FOO": true,
+			"CONFIG_HAVE_CFI_ICALL_NORMALIZE_INTEGERS_RUSTC": true,
+		},
+	}
+	if err := ValidateRustToolchainEquivalence(map[string]string{
+		"CONFIG_RUST":          "y",
+		"CONFIG_RUSTC_VERSION": "107800",
+	}, actual); err != nil {
+		t.Fatalf("ValidateRustToolchainEquivalence() rejected dynamic-only changes: %v", err)
+	}
+	actual.Effective["CONFIG_STRUCTURAL_NEW"] = "y"
+	actual.Written["CONFIG_STRUCTURAL_NEW"] = true
+	if err := ValidateRustToolchainEquivalence(map[string]string{"CONFIG_RUST": "y"}, actual); err == nil {
+		t.Fatal("ValidateRustToolchainEquivalence() accepted structural change")
+	}
+}
+
 func TestParseConfigSkipsUnsetComments(t *testing.T) {
 	raw, err := ParseConfig(strings.NewReader("# CONFIG_DEFAULT_ON is not set\n"))
 	if err != nil {

--- a/internal/kconfig/kbuild.go
+++ b/internal/kconfig/kbuild.go
@@ -3174,6 +3174,7 @@ func kbuildObjectSettingName(variable string) (string, string, bool) {
 		"KASAN_SANITIZE",
 		"KCSAN_INSTRUMENT_BARRIERS",
 		"KCSAN_SANITIZE",
+		"OBJECT_FILES_NON_STANDARD",
 		"UBSAN_INTEGER_WRAP",
 		"UBSAN_SANITIZE",
 		"UBSAN_SIGNED_WRAP",

--- a/internal/kconfig/rust_profile.go
+++ b/internal/kconfig/rust_profile.go
@@ -6,48 +6,73 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
-const RustProfileSchema = "linux-rust-profile-v1"
+const RustProfileSchema = "linux-rust-profile-v2"
 
 type RustProfile struct {
-	Schema            string                  `json:"schema"`
-	Architecture      string                  `json:"architecture"`
-	SourceLayout      string                  `json:"source_layout"`
-	Target            RustTargetRecipe        `json:"target"`
-	CommonFlags       []string                `json:"common_flags"`
-	TargetFlags       RustFlagSet             `json:"target_flags"`
-	Module            RustModuleProfile       `json:"module"`
-	Bindgen           RustBindgenProfile      `json:"bindgen"`
-	ProcMacros        []RustProcMacroProfile  `json:"proc_macros"`
-	Crates            []RustCrateProfile      `json:"crates"`
-	GeneratedAssembly []RustGeneratedAssembly `json:"generated_assembly,omitempty"`
-	Exports           RustExportsProfile      `json:"exports"`
-	RuntimeObjects    []RustRuntimeObject     `json:"runtime_objects"`
+	Schema             string                  `json:"schema"`
+	Architecture       string                  `json:"architecture"`
+	SourceLayout       string                  `json:"source_layout"`
+	Target             RustTargetRecipe        `json:"target"`
+	CommonFlags        RustVersionedFlagSet    `json:"common_flags"`
+	TargetFlags        RustFlagSet             `json:"target_flags"`
+	Module             RustModuleProfile       `json:"module"`
+	Bindgen            RustBindgenProfile      `json:"bindgen"`
+	ProcMacros         []RustProcMacroProfile  `json:"proc_macros"`
+	Crates             []RustCrateProfile      `json:"crates"`
+	GeneratedAssembly  []RustGeneratedAssembly `json:"generated_assembly,omitempty"`
+	Exports            RustExportsProfile      `json:"exports"`
+	RuntimeObjects     []RustRuntimeObject     `json:"runtime_objects"`
+	UnsupportedConfigs []string                `json:"unsupported_configs"`
 }
 
 type RustTargetRecipe struct {
-	GeneratorSource string `json:"generator_source"`
-	Stdin           string `json:"stdin"`
-	Output          string `json:"output"`
+	Kind            string `json:"kind"`
+	GeneratorSource string `json:"generator_source,omitempty"`
+	Stdin           string `json:"stdin,omitempty"`
+	Output          string `json:"output,omitempty"`
+	BuiltinTriple   string `json:"builtin_triple,omitempty"`
+}
+
+type RustVersionedFlagSet struct {
+	Always            []string               `json:"always"`
+	VersionPredicates []RustVersionPredicate `json:"version_predicates"`
 }
 
 type RustFlagSet struct {
-	Always      []string               `json:"always"`
-	Conditional []RustConditionalFlags `json:"conditional"`
+	Always            []string               `json:"always"`
+	Conditional       []RustConditionalFlags `json:"conditional"`
+	VersionPredicates []RustVersionPredicate `json:"version_predicates"`
 }
 
+// RustVersionPredicate transforms a flag list in source order. Consumers remove
+// flags before adding flags from the selected semver branch.
+type RustVersionPredicate struct {
+	AtLeast    string   `json:"at_least"`
+	Add        []string `json:"add"`
+	Remove     []string `json:"remove"`
+	ElseAdd    []string `json:"else_add"`
+	ElseRemove []string `json:"else_remove"`
+}
+
+// VersionPredicates transform Flags only; ElseFlags describe the false branch.
+// UnlessConfig suppresses the true branch when that symbol is enabled.
 type RustConditionalFlags struct {
-	Config    string   `json:"config"`
-	Equals    string   `json:"equals,omitempty"`
-	Flags     []string `json:"flags"`
-	ElseFlags []string `json:"else_flags,omitempty"`
+	Config            string                 `json:"config"`
+	Equals            string                 `json:"equals,omitempty"`
+	UnlessConfig      string                 `json:"unless_config,omitempty"`
+	Flags             []string               `json:"flags"`
+	ElseFlags         []string               `json:"else_flags"`
+	VersionPredicates []RustVersionPredicate `json:"version_predicates"`
 }
 
 type RustModuleProfile struct {
-	AllowedFeatures []string `json:"allowed_features"`
-	Flags           []string `json:"flags"`
+	AllowedFeatures   []string               `json:"allowed_features"`
+	Flags             []string               `json:"flags"`
+	VersionPredicates []RustVersionPredicate `json:"version_predicates"`
 }
 
 type RustBindgenProfile struct {
@@ -68,16 +93,17 @@ type RustProcMacroProfile struct {
 }
 
 type RustCrateProfile struct {
-	Name            string   `json:"name"`
-	Source          string   `json:"source"`
-	SourcePrefixes  []string `json:"source_prefixes"`
-	SourceFiles     []string `json:"source_files"`
-	GeneratedInputs []string `json:"generated_inputs"`
-	Deps            []string `json:"deps"`
-	Externs         []string `json:"externs"`
-	Flags           []string `json:"flags"`
-	SkipFlags       []string `json:"skip_flags"`
-	ObjcopyFlags    []string `json:"objcopy_flags"`
+	Name              string                 `json:"name"`
+	Source            string                 `json:"source"`
+	SourcePrefixes    []string               `json:"source_prefixes"`
+	SourceFiles       []string               `json:"source_files"`
+	GeneratedInputs   []string               `json:"generated_inputs"`
+	Deps              []string               `json:"deps"`
+	Externs           []string               `json:"externs"`
+	Flags             []string               `json:"flags"`
+	SkipFlags         []string               `json:"skip_flags"`
+	ObjcopyFlags      []string               `json:"objcopy_flags"`
+	VersionPredicates []RustVersionPredicate `json:"version_predicates"`
 }
 
 type RustGeneratedAssembly struct {
@@ -108,19 +134,25 @@ func (p *RustProfile) JSON() ([]byte, error) {
 
 func GenerateRustProfile(sourceRoot, arch string) (*RustProfile, error) {
 	sourceRoot = filepath.Clean(sourceRoot)
-	if arch != "x86" && arch != "x86_64" {
-		return nil, fmt.Errorf("Rust profile generation supports only x86_64, got ARCH=%q", arch)
+	architecture, sourceArch, err := rustProfileArchitecture(arch)
+	if err != nil {
+		return nil, err
 	}
 
 	rootMake, err := readRustProfileFile(sourceRoot, "Makefile")
 	if err != nil {
 		return nil, err
 	}
-	archMake, err := readRustProfileFile(sourceRoot, "arch/x86/Makefile")
+	archMakePath := "arch/" + sourceArch + "/Makefile"
+	archMake, err := readRustProfileFile(sourceRoot, archMakePath)
 	if err != nil {
 		return nil, err
 	}
 	buildMake, err := readRustProfileFile(sourceRoot, "scripts/Makefile.build")
+	if err != nil {
+		return nil, err
+	}
+	debugMake, err := readRustProfileFile(sourceRoot, "scripts/Makefile.debug")
 	if err != nil {
 		return nil, err
 	}
@@ -227,10 +259,36 @@ func GenerateRustProfile(sourceRoot, arch string) (*RustProfile, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, marker := range []string{"KernelConfig::from_stdin()", `cfg.has("X86_64")`} {
+	for _, marker := range []string{"KernelConfig::from_stdin()", "CONFIG_RUSTC_VERSION"} {
 		if !strings.Contains(targetGenerator, marker) {
 			return nil, fmt.Errorf("unsupported Rust target generator: missing %q", marker)
 		}
+	}
+	if architecture == "x86_64" {
+		for _, marker := range []string{
+			`cfg.has("X86_64")`,
+			"rustc_version_atleast(1, 86, 0)",
+			"rustc_version_atleast(1, 91, 0)",
+			"rustc_version_atleast(1, 98, 0)",
+		} {
+			if !strings.Contains(targetGenerator, marker) {
+				return nil, fmt.Errorf("unsupported x86 Rust target generator: missing %q", marker)
+			}
+		}
+	} else {
+		for _, marker := range []string{`cfg.has("ARM64")`, "aarch64-unknown-none"} {
+			if !strings.Contains(targetGenerator, marker) {
+				return nil, fmt.Errorf("unsupported arm64 Rust target generator: missing %q", marker)
+			}
+		}
+	}
+	coreEditionAtLeast, err := rustcMinimumVersion(
+		rustMake,
+		"core edition",
+		`(?m)^core-edition[ \t]*:=[ \t]*\$\(if[ \t]+\$\(call[ \t]+rustc-min-version,[ \t]*([0-9]+)\),2024,2021\)[ \t]*$`,
+	)
+	if err != nil {
+		return nil, err
 	}
 	procMacroUsesRustcCfg, err := rustProcMacroUsesRustcCfg(rustMake)
 	if err != nil {
@@ -240,7 +298,7 @@ func GenerateRustProfile(sourceRoot, arch string) (*RustProfile, error) {
 		return nil, fmt.Errorf("pin-init Rust layout requires proc macros to consume rustc_cfg")
 	}
 
-	redirects, err := makeWords(rustMake, "redirect-intrinsics")
+	redirects, err := rustRedirectIntrinsics(rustMake, architecture)
 	if err != nil {
 		return nil, err
 	}
@@ -252,21 +310,73 @@ func GenerateRustProfile(sourceRoot, arch string) (*RustProfile, error) {
 		coreObjcopy = append(coreObjcopy, "--redefine-sym", symbol+"=__rust"+symbol)
 	}
 
+	target := RustTargetRecipe{}
 	alwaysTargetFlags := append([]string(nil), baseFlags...)
-	for _, requiredFlag := range []string{
-		"--target=$(objtree)/scripts/target.json",
-		"-Ctarget-feature=-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2",
-		"-Cno-redzone=y",
-		"-Ccode-model=kernel",
-	} {
-		if !strings.Contains(archMake, "KBUILD_RUSTFLAGS += "+requiredFlag) {
-			return nil, fmt.Errorf("arch/x86/Makefile does not contain supported Rust flag %q", requiredFlag)
+	targetVersionPredicates := []RustVersionPredicate{}
+	unsupportedConfigs := []string{}
+	switch architecture {
+	case "x86_64":
+		target = RustTargetRecipe{
+			Kind:            "generated",
+			GeneratorSource: "scripts/generate_rust_target.rs",
+			Stdin:           "config_auto_conf",
+			Output:          "scripts/target.json",
 		}
-		alwaysTargetFlags = append(alwaysTargetFlags, strings.ReplaceAll(requiredFlag, "$(objtree)/scripts/target.json", "{target_spec}"))
+		for _, requiredFlag := range []string{
+			"--target=$(objtree)/scripts/target.json",
+			"-Ctarget-feature=-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2",
+			"-Cno-redzone=y",
+			"-Ccode-model=kernel",
+		} {
+			if !strings.Contains(archMake, "KBUILD_RUSTFLAGS += "+requiredFlag) {
+				return nil, fmt.Errorf("%s does not contain supported Rust flag %q", archMakePath, requiredFlag)
+			}
+			alwaysTargetFlags = append(alwaysTargetFlags, strings.ReplaceAll(requiredFlag, "$(objtree)/scripts/target.json", "{target_spec}"))
+		}
+	case "aarch64":
+		target = RustTargetRecipe{
+			Kind:          "builtin",
+			BuiltinTriple: "aarch64-unknown-none",
+		}
+		targetAtLeast, err := rustcMinimumVersion(
+			archMake,
+			"arm64 soft-float target",
+			`(?m)^ifeq[ \t]*\(\$\(call[ \t]+rustc-min-version,[ \t]*([0-9]+)\),y\)[ \t]*$`,
+		)
+		if err != nil {
+			return nil, err
+		}
+		for _, marker := range []string{
+			"KBUILD_RUSTFLAGS += --target=aarch64-unknown-none-softfloat",
+			`KBUILD_RUSTFLAGS += --target=aarch64-unknown-none -Ctarget-feature="-neon"`,
+		} {
+			if !strings.Contains(archMake, marker) {
+				return nil, fmt.Errorf("%s does not contain supported Rust target marker %q", archMakePath, marker)
+			}
+		}
+		alwaysTargetFlags = append(alwaysTargetFlags,
+			"--target=aarch64-unknown-none",
+			"-Ctarget-feature=-neon",
+		)
+		targetVersionPredicates = append(targetVersionPredicates, newRustVersionPredicate(
+			targetAtLeast,
+			[]string{"--target=aarch64-unknown-none-softfloat"},
+			[]string{"--target=aarch64-unknown-none", "-Ctarget-feature=-neon"},
+			nil,
+			[]string{"--target=aarch64-unknown-none-softfloat"},
+		))
+		unsupportedConfigs = []string{
+			"CONFIG_CPU_BIG_ENDIAN",
+			"CONFIG_CFI",
+			"CONFIG_CFI_CLANG",
+			"CONFIG_KASAN",
+			"CONFIG_KCSAN",
+			"CONFIG_UBSAN",
+		}
 	}
 	alwaysTargetFlags = append(alwaysTargetFlags, "@{rustc_cfg}")
 
-	conditional, err := rustTargetConditionalFlags(rootMake, archMake)
+	conditional, err := rustTargetConditionalFlags(rootMake, debugMake, archMake, architecture)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +400,7 @@ func GenerateRustProfile(sourceRoot, arch string) (*RustProfile, error) {
 		})
 	}
 
-	crates := rustCrateGraph(layout, coreObjcopy)
+	crates := rustCrateGraph(layout, coreObjcopy, coreEditionAtLeast)
 	generatedAssembly, err := rustGeneratedAssembly(sourceRoot, rustMake, layout)
 	if err != nil {
 		return nil, err
@@ -336,19 +446,18 @@ func GenerateRustProfile(sourceRoot, arch string) (*RustProfile, error) {
 		RustRuntimeObject{Path: "rust/exports.o"},
 	)
 
-	return &RustProfile{
+	profile := &RustProfile{
 		Schema:       RustProfileSchema,
-		Architecture: "x86_64",
+		Architecture: architecture,
 		SourceLayout: layout,
-		Target: RustTargetRecipe{
-			GeneratorSource: "scripts/generate_rust_target.rs",
-			Stdin:           "config_auto_conf",
-			Output:          "scripts/target.json",
+		Target:       target,
+		CommonFlags: RustVersionedFlagSet{
+			Always: commonFlags,
 		},
-		CommonFlags: commonFlags,
 		TargetFlags: RustFlagSet{
-			Always:      alwaysTargetFlags,
-			Conditional: conditional,
+			Always:            alwaysTargetFlags,
+			Conditional:       conditional,
+			VersionPredicates: targetVersionPredicates,
 		},
 		Module: RustModuleProfile{
 			AllowedFeatures: allowedFeatures,
@@ -376,11 +485,14 @@ func GenerateRustProfile(sourceRoot, arch string) (*RustProfile, error) {
 			Source: "rust/exports.c",
 			Crates: []string{"core", "helpers", "bindings", "kernel"},
 		},
-		RuntimeObjects: runtime,
-	}, nil
+		RuntimeObjects:     runtime,
+		UnsupportedConfigs: unsupportedConfigs,
+	}
+	normalizeRustProfile(profile)
+	return profile, nil
 }
 
-func rustCrateGraph(layout string, coreObjcopy []string) []RustCrateProfile {
+func rustCrateGraph(layout string, coreObjcopy []string, coreEditionAtLeast string) []RustCrateProfile {
 	empty := []string{}
 	crates := []RustCrateProfile{
 		{
@@ -391,9 +503,16 @@ func rustCrateGraph(layout string, coreObjcopy []string) []RustCrateProfile {
 			GeneratedInputs: empty,
 			Deps:            empty,
 			Externs:         empty,
-			Flags:           []string{"--edition=2024", "--cfg", "no_fp_fmt_parse"},
-			SkipFlags:       []string{"--edition=2021", "-Wunreachable_pub"},
+			Flags:           []string{"--cfg", "no_fp_fmt_parse"},
+			SkipFlags:       []string{"-Wunreachable_pub"},
 			ObjcopyFlags:    coreObjcopy,
+			VersionPredicates: []RustVersionPredicate{newRustVersionPredicate(
+				coreEditionAtLeast,
+				[]string{"--edition=2024"},
+				[]string{"--edition=2021"},
+				nil,
+				[]string{"--edition=2024"},
+			)},
 		},
 		{
 			Name:            "compiler_builtins",
@@ -493,45 +612,164 @@ func rustGeneratedAssembly(sourceRoot, rustMake, layout string) ([]RustGenerated
 	return entries, nil
 }
 
-func rustTargetConditionalFlags(rootMake, archMake string) ([]RustConditionalFlags, error) {
+func rustTargetConditionalFlags(rootMake, debugMake, archMake, architecture string) ([]RustConditionalFlags, error) {
 	required := []struct {
-		content string
-		marker  string
-		group   RustConditionalFlags
+		marker string
+		group  RustConditionalFlags
 	}{
-		{rootMake, "KBUILD_RUSTFLAGS += -Copt-level=s", RustConditionalFlags{Config: "CONFIG_CC_OPTIMIZE_FOR_SIZE", Equals: "y", Flags: []string{"-Copt-level=s"}, ElseFlags: []string{"-Copt-level=2"}}},
-		{rootMake, "CONFIG_RUST_DEBUG_ASSERTIONS", RustConditionalFlags{Config: "CONFIG_RUST_DEBUG_ASSERTIONS", Equals: "y", Flags: []string{"-Cdebug-assertions=y"}, ElseFlags: []string{"-Cdebug-assertions=n"}}},
-		{rootMake, "CONFIG_RUST_OVERFLOW_CHECKS", RustConditionalFlags{Config: "CONFIG_RUST_OVERFLOW_CHECKS", Equals: "y", Flags: []string{"-Coverflow-checks=y"}, ElseFlags: []string{"-Coverflow-checks=n"}}},
-		{rootMake, "ifdef CONFIG_FRAME_POINTER", RustConditionalFlags{Config: "CONFIG_FRAME_POINTER", Equals: "y", Flags: []string{"-Cforce-frame-pointers=y", "-Zllvm_module_flag=frame-pointer:u32:2:max"}}},
-		{archMake, "RETHUNK_RUSTFLAGS", RustConditionalFlags{Config: "CONFIG_MITIGATION_RETHUNK", Equals: "y", Flags: []string{"-Zfunction-return=thunk-extern"}}},
-		{archMake, "CONFIG_X86_KERNEL_IBT", RustConditionalFlags{Config: "CONFIG_X86_KERNEL_IBT", Equals: "y", Flags: []string{"-Zcf-protection=branch", "-Cjump-tables=n"}}},
-		{archMake, "PADDING_RUSTFLAGS", RustConditionalFlags{Config: "CONFIG_CALL_PADDING", Equals: "y", Flags: []string{"-Zpatchable-function-entry={CONFIG_FUNCTION_PADDING_BYTES},{CONFIG_FUNCTION_PADDING_BYTES}"}}},
+		{
+			"KBUILD_RUSTFLAGS += -Copt-level=s",
+			newRustConditionalFlags(
+				"CONFIG_CC_OPTIMIZE_FOR_SIZE",
+				[]string{"-Copt-level=s"},
+				[]string{"-Copt-level=2"},
+				nil,
+			),
+		},
+		{
+			"CONFIG_RUST_DEBUG_ASSERTIONS",
+			newRustConditionalFlags(
+				"CONFIG_RUST_DEBUG_ASSERTIONS",
+				[]string{"-Cdebug-assertions=y"},
+				[]string{"-Cdebug-assertions=n"},
+				nil,
+			),
+		},
+		{
+			"CONFIG_RUST_OVERFLOW_CHECKS",
+			newRustConditionalFlags(
+				"CONFIG_RUST_OVERFLOW_CHECKS",
+				[]string{"-Coverflow-checks=y"},
+				[]string{"-Coverflow-checks=n"},
+				nil,
+			),
+		},
+		{
+			"ifdef CONFIG_FRAME_POINTER",
+			newRustConditionalFlags(
+				"CONFIG_FRAME_POINTER",
+				[]string{"-Cforce-frame-pointers=y"},
+				nil,
+				nil,
+			),
+		},
 	}
-	out := make([]RustConditionalFlags, 0, len(required)+5)
+	out := make([]RustConditionalFlags, 0, len(required)+8)
 	for _, item := range required {
-		if !strings.Contains(item.content, item.marker) {
+		if !strings.Contains(rootMake, item.marker) {
 			return nil, fmt.Errorf("unsupported Rust flag layout: missing %q", item.marker)
 		}
 		out = append(out, item.group)
 	}
-	if strings.Contains(rootMake, "KBUILD_RUSTFLAGS-$(CONFIG_WERROR) += -Dwarnings") {
-		out = append(out, RustConditionalFlags{
-			Config: "CONFIG_WERROR",
-			Equals: "y",
-			Flags:  []string{"-Dwarnings"},
-		})
+	framePointerAtLeast, err := rustcMinimumVersion(
+		rootMake,
+		"frame-pointer module flag",
+		`(?m)^KBUILD_RUSTFLAGS[ \t]*\+=[ \t]*\$\(if[ \t]+\$\(call[ \t]+rustc-min-version,[ \t]*([0-9]+)\),,-Zllvm_module_flag=frame-pointer:u32:2:max\)[ \t]*$`,
+	)
+	if err != nil {
+		return nil, err
 	}
+	out[len(out)-1].VersionPredicates = []RustVersionPredicate{newRustVersionPredicate(
+		framePointerAtLeast,
+		nil,
+		[]string{"-Zllvm_module_flag=frame-pointer:u32:2:max"},
+		[]string{"-Zllvm_module_flag=frame-pointer:u32:2:max"},
+		nil,
+	)}
+	if strings.Contains(rootMake, "KBUILD_RUSTFLAGS-$(CONFIG_WERROR) += -Dwarnings") {
+		out = append(out, newRustConditionalFlags(
+			"CONFIG_WERROR",
+			[]string{"-Dwarnings"},
+			nil,
+			nil,
+		))
+	}
+	for _, marker := range []string{
+		"CONFIG_DEBUG_INFO",
+		"DEBUG_RUSTFLAGS",
+		"-Cdebuginfo=2",
+		"CONFIG_DEBUG_INFO_DWARF5",
+		"-Zdwarf-version=5",
+	} {
+		if !strings.Contains(debugMake, marker) {
+			return nil, fmt.Errorf("unsupported Rust debug flag layout: missing %q", marker)
+		}
+	}
+	out = append(out,
+		newRustConditionalFlags(
+			"CONFIG_DEBUG_INFO",
+			[]string{"-Cdebuginfo=2"},
+			nil,
+			nil,
+		),
+		newRustConditionalFlags(
+			"CONFIG_DEBUG_INFO_DWARF5",
+			[]string{"-Zdwarf-version=5"},
+			nil,
+			nil,
+		),
+	)
+
+	switch architecture {
+	case "x86_64":
+		return rustX86ConditionalFlags(archMake, out)
+	case "aarch64":
+		return rustArm64ConditionalFlags(archMake, out)
+	default:
+		return nil, fmt.Errorf("unsupported Rust profile architecture %q", architecture)
+	}
+}
+
+func rustX86ConditionalFlags(archMake string, out []RustConditionalFlags) ([]RustConditionalFlags, error) {
+	for _, marker := range []string{"RETHUNK_RUSTFLAGS", "CONFIG_X86_KERNEL_IBT", "PADDING_RUSTFLAGS"} {
+		if !strings.Contains(archMake, marker) {
+			return nil, fmt.Errorf("unsupported x86 Rust flag layout: missing %q", marker)
+		}
+	}
+	out = append(out, newRustConditionalFlags(
+		"CONFIG_MITIGATION_RETHUNK",
+		[]string{"-Zfunction-return=thunk-extern"},
+		nil,
+		nil,
+	))
+	jumpTablesAtLeast, err := rustcMinimumVersion(
+		archMake,
+		"x86 IBT jump-table flag",
+		`(?m)^KBUILD_RUSTFLAGS[ \t]*\+=[ \t]*-Zcf-protection=branch[ \t]+\$\(if[ \t]+\$\(call[ \t]+rustc-min-version,[ \t]*([0-9]+)\),-Cjump-tables=n,-Zno-jump-tables\)[ \t]*$`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, newRustConditionalFlags(
+		"CONFIG_X86_KERNEL_IBT",
+		[]string{"-Zcf-protection=branch"},
+		nil,
+		[]RustVersionPredicate{newRustVersionPredicate(
+			jumpTablesAtLeast,
+			[]string{"-Cjump-tables=n"},
+			[]string{"-Zno-jump-tables"},
+			[]string{"-Zno-jump-tables"},
+			[]string{"-Cjump-tables=n"},
+		)},
+	))
+	out = append(out, newRustConditionalFlags(
+		"CONFIG_CALL_PADDING",
+		[]string{"-Zpatchable-function-entry={CONFIG_FUNCTION_PADDING_BYTES},{CONFIG_FUNCTION_PADDING_BYTES}"},
+		nil,
+		nil,
+	))
 
 	if strings.Contains(archMake, "ifdef CONFIG_X86_NATIVE_CPU") {
 		if !strings.Contains(archMake, "KBUILD_RUSTFLAGS += -Ctarget-cpu=native") ||
 			!strings.Contains(archMake, "KBUILD_RUSTFLAGS += -Ctarget-cpu=x86-64 -Ztune-cpu=generic") {
 			return nil, fmt.Errorf("unsupported CONFIG_X86_NATIVE_CPU Rust flag layout")
 		}
-		out = append(out, RustConditionalFlags{
-			Config: "CONFIG_X86_NATIVE_CPU", Equals: "y",
-			Flags:     []string{"-Ctarget-cpu=native"},
-			ElseFlags: []string{"-Ctarget-cpu=x86-64", "-Ztune-cpu=generic"},
-		})
+		out = append(out, newRustConditionalFlags(
+			"CONFIG_X86_NATIVE_CPU",
+			[]string{"-Ctarget-cpu=native"},
+			[]string{"-Ctarget-cpu=x86-64", "-Ztune-cpu=generic"},
+			nil,
+		))
 		return out, nil
 	}
 
@@ -545,12 +783,76 @@ func rustTargetConditionalFlags(rootMake, archMake string) ([]RustConditionalFla
 		if err := rejectMakeWords("x86 Rust CPU flags", flags); err != nil {
 			return nil, err
 		}
-		out = append(out, RustConditionalFlags{
-			Config: "CONFIG_" + match[1],
-			Equals: "y",
-			Flags:  flags,
-		})
+		out = append(out, newRustConditionalFlags(
+			"CONFIG_"+match[1],
+			flags,
+			nil,
+			nil,
+		))
 	}
+	return out, nil
+}
+
+func rustArm64ConditionalFlags(archMake string, out []RustConditionalFlags) ([]RustConditionalFlags, error) {
+	for _, marker := range []string{
+		"CONFIG_UNWIND_TABLES",
+		"KBUILD_RUSTFLAGS += -Cforce-unwind-tables=n",
+		"KBUILD_RUSTFLAGS += -Cforce-unwind-tables=y -Zuse-sync-unwind=n",
+		"CONFIG_ARM64_BTI_KERNEL",
+		"-Zbranch-protection=bti,pac-ret",
+		"CONFIG_ARM64_PTR_AUTH_KERNEL",
+		"-Zbranch-protection=pac-ret",
+		"CONFIG_SHADOW_CALL_STACK",
+		"KBUILD_RUSTFLAGS += -Zfixed-x18",
+	} {
+		if !strings.Contains(archMake, marker) {
+			return nil, fmt.Errorf("unsupported arm64 Rust flag layout: missing %q", marker)
+		}
+	}
+	unwindAtLeast, err := rustcMinimumVersion(
+		archMake,
+		"arm64 unwind module flag",
+		`(?m)^KBUILD_RUSTFLAGS[ \t]*\+=[ \t]*\$\(if[ \t]+\$\(call[ \t]+rustc-min-version,[ \t]*([0-9]+)\),,-Zllvm_module_flag=uwtable:u32:2:max\)[ \t]*$`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, newRustConditionalFlags(
+		"CONFIG_UNWIND_TABLES",
+		[]string{"-Cforce-unwind-tables=y", "-Zuse-sync-unwind=n"},
+		[]string{"-Cforce-unwind-tables=n"},
+		[]RustVersionPredicate{newRustVersionPredicate(
+			unwindAtLeast,
+			nil,
+			[]string{"-Zllvm_module_flag=uwtable:u32:2:max"},
+			[]string{"-Zllvm_module_flag=uwtable:u32:2:max"},
+			nil,
+		)},
+	))
+	ptrAuth := newRustConditionalFlags(
+		"CONFIG_ARM64_PTR_AUTH_KERNEL",
+		[]string{"-Zbranch-protection=pac-ret"},
+		nil,
+		nil,
+	)
+	ptrAuth.UnlessConfig = "CONFIG_ARM64_BTI_KERNEL"
+	// Preserve the Makefile's if/else-if relationship: BTI includes PAC, so
+	// the pointer-authentication-only flag must not also be emitted.
+	out = append(out,
+		newRustConditionalFlags(
+			"CONFIG_ARM64_BTI_KERNEL",
+			[]string{"-Zbranch-protection=bti,pac-ret"},
+			nil,
+			nil,
+		),
+		ptrAuth,
+		newRustConditionalFlags(
+			"CONFIG_SHADOW_CALL_STACK",
+			[]string{"-Zfixed-x18"},
+			nil,
+			nil,
+		),
+	)
 	return out, nil
 }
 
@@ -564,6 +866,121 @@ func rustProcMacroUsesRustcCfg(rustMake string) (bool, error) {
 		block = block[:end]
 	}
 	return strings.Contains(block, "@$(objtree)/include/generated/rustc_cfg"), nil
+}
+
+func rustProfileArchitecture(arch string) (architecture, sourceArch string, err error) {
+	switch arch {
+	case "x86", "x86_64":
+		return "x86_64", "x86", nil
+	case "arm64", "aarch64":
+		return "aarch64", "arm64", nil
+	default:
+		return "", "", fmt.Errorf("Rust profile generation supports only x86_64 and arm64, got ARCH=%q", arch)
+	}
+}
+
+func rustRedirectIntrinsics(rustMake, architecture string) ([]string, error) {
+	redirects, err := makeWords(rustMake, "redirect-intrinsics")
+	if err != nil {
+		return nil, err
+	}
+	if architecture != "aarch64" {
+		return redirects, nil
+	}
+	for _, marker := range []string{
+		"ifneq ($(or $(CONFIG_ARM64)",
+		"__ashrti3",
+		"__ashlti3",
+		"__lshrti3",
+	} {
+		if !strings.Contains(rustMake, marker) {
+			return nil, fmt.Errorf("unsupported arm64 redirect-intrinsics layout: missing %q", marker)
+		}
+	}
+	return append(redirects, "__ashrti3", "__ashlti3", "__lshrti3"), nil
+}
+
+func rustcMinimumVersion(content, context, pattern string) (string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("compile %s rustc-version pattern: %w", context, err)
+	}
+	match := re.FindStringSubmatch(content)
+	if len(match) != 2 {
+		return "", fmt.Errorf("unsupported %s layout: missing rustc minimum-version predicate", context)
+	}
+	encoded, err := strconv.Atoi(match[1])
+	if err != nil {
+		return "", fmt.Errorf("parse %s rustc minimum version %q: %w", context, match[1], err)
+	}
+	major := encoded / 100000
+	minor := (encoded / 100) % 1000
+	patch := encoded % 100
+	if major < 1 || minor > 999 || patch > 99 {
+		return "", fmt.Errorf("unsupported %s rustc minimum version %q", context, match[1])
+	}
+	return fmt.Sprintf("%d.%d.%d", major, minor, patch), nil
+}
+
+func newRustVersionPredicate(atLeast string, add, remove, elseAdd, elseRemove []string) RustVersionPredicate {
+	return RustVersionPredicate{
+		AtLeast:    atLeast,
+		Add:        nonNilStrings(add),
+		Remove:     nonNilStrings(remove),
+		ElseAdd:    nonNilStrings(elseAdd),
+		ElseRemove: nonNilStrings(elseRemove),
+	}
+}
+
+func newRustConditionalFlags(config string, flags, elseFlags []string, predicates []RustVersionPredicate) RustConditionalFlags {
+	return RustConditionalFlags{
+		Config:            config,
+		Equals:            "y",
+		Flags:             nonNilStrings(flags),
+		ElseFlags:         nonNilStrings(elseFlags),
+		VersionPredicates: nonNilRustVersionPredicates(predicates),
+	}
+}
+
+func normalizeRustProfile(profile *RustProfile) {
+	profile.CommonFlags.Always = nonNilStrings(profile.CommonFlags.Always)
+	profile.CommonFlags.VersionPredicates = nonNilRustVersionPredicates(profile.CommonFlags.VersionPredicates)
+	profile.TargetFlags.Always = nonNilStrings(profile.TargetFlags.Always)
+	profile.TargetFlags.VersionPredicates = nonNilRustVersionPredicates(profile.TargetFlags.VersionPredicates)
+	for i := range profile.TargetFlags.Conditional {
+		condition := &profile.TargetFlags.Conditional[i]
+		condition.Flags = nonNilStrings(condition.Flags)
+		condition.ElseFlags = nonNilStrings(condition.ElseFlags)
+		condition.VersionPredicates = nonNilRustVersionPredicates(condition.VersionPredicates)
+	}
+	profile.Module.AllowedFeatures = nonNilStrings(profile.Module.AllowedFeatures)
+	profile.Module.Flags = nonNilStrings(profile.Module.Flags)
+	profile.Module.VersionPredicates = nonNilRustVersionPredicates(profile.Module.VersionPredicates)
+	for i := range profile.Crates {
+		crate := &profile.Crates[i]
+		crate.VersionPredicates = nonNilRustVersionPredicates(crate.VersionPredicates)
+	}
+	profile.UnsupportedConfigs = nonNilStrings(profile.UnsupportedConfigs)
+}
+
+func nonNilRustVersionPredicates(predicates []RustVersionPredicate) []RustVersionPredicate {
+	if predicates == nil {
+		return []RustVersionPredicate{}
+	}
+	for i := range predicates {
+		predicates[i].Add = nonNilStrings(predicates[i].Add)
+		predicates[i].Remove = nonNilStrings(predicates[i].Remove)
+		predicates[i].ElseAdd = nonNilStrings(predicates[i].ElseAdd)
+		predicates[i].ElseRemove = nonNilStrings(predicates[i].ElseRemove)
+	}
+	return predicates
+}
+
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
 }
 
 func readRustProfileFile(root, path string) (string, error) {

--- a/internal/kconfig/rust_profile_test.go
+++ b/internal/kconfig/rust_profile_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -17,6 +18,49 @@ func TestGenerateRustProfileLegacyLayout(t *testing.T) {
 	if profile.Schema != RustProfileSchema || profile.Architecture != "x86_64" || profile.SourceLayout != "legacy" {
 		t.Fatalf("profile identity = %#v", profile)
 	}
+	if profile.Schema != "linux-rust-profile-v2" {
+		t.Fatalf("schema = %q, want linux-rust-profile-v2", profile.Schema)
+	}
+	if profile.Target.Kind != "generated" ||
+		profile.Target.GeneratorSource != "scripts/generate_rust_target.rs" ||
+		profile.Target.Stdin != "config_auto_conf" ||
+		profile.Target.Output != "scripts/target.json" ||
+		profile.Target.BuiltinTriple != "" {
+		t.Fatalf("x86 target recipe = %#v", profile.Target)
+	}
+	if len(profile.CommonFlags.Always) == 0 || profile.CommonFlags.Always[0] != "--edition=2021" {
+		t.Fatalf("common flags = %#v", profile.CommonFlags)
+	}
+	core := rustProfileCrate(profile, "core")
+	if got, want := core.VersionPredicates, []RustVersionPredicate{newRustVersionPredicate(
+		"1.87.0",
+		[]string{"--edition=2024"},
+		[]string{"--edition=2021"},
+		nil,
+		[]string{"--edition=2024"},
+	)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("core version predicates = %#v, want %#v", got, want)
+	}
+	framePointer := rustProfileConditional(profile, "CONFIG_FRAME_POINTER")
+	if got, want := framePointer.VersionPredicates, []RustVersionPredicate{newRustVersionPredicate(
+		"1.98.0",
+		nil,
+		[]string{"-Zllvm_module_flag=frame-pointer:u32:2:max"},
+		[]string{"-Zllvm_module_flag=frame-pointer:u32:2:max"},
+		nil,
+	)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("frame-pointer version predicates = %#v, want %#v", got, want)
+	}
+	ibt := rustProfileConditional(profile, "CONFIG_X86_KERNEL_IBT")
+	if got, want := ibt.VersionPredicates, []RustVersionPredicate{newRustVersionPredicate(
+		"1.93.0",
+		[]string{"-Cjump-tables=n"},
+		[]string{"-Zno-jump-tables"},
+		[]string{"-Zno-jump-tables"},
+		[]string{"-Cjump-tables=n"},
+	)}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("IBT version predicates = %#v, want %#v", got, want)
+	}
 	if got, want := profile.Module.AllowedFeatures, []string{"arbitrary_self_types", "lint_reasons", "used_with_arg"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("allowed features = %v, want %v", got, want)
 	}
@@ -28,6 +72,10 @@ func TestGenerateRustProfileLegacyLayout(t *testing.T) {
 	}
 	if len(profile.GeneratedAssembly) != 0 {
 		t.Fatalf("legacy generated assembly = %#v", profile.GeneratedAssembly)
+	}
+	if !hasRustConditionalFlag(profile.TargetFlags.Conditional, "CONFIG_DEBUG_INFO", "-Cdebuginfo=2") ||
+		!hasRustConditionalFlag(profile.TargetFlags.Conditional, "CONFIG_DEBUG_INFO_DWARF5", "-Zdwarf-version=5") {
+		t.Fatalf("Rust debug flags are missing: %#v", profile.TargetFlags.Conditional)
 	}
 	for _, path := range rustRuntimePaths(profile) {
 		if path == "rust/pin_init.o" {
@@ -44,6 +92,136 @@ func TestGenerateRustProfileLegacyLayout(t *testing.T) {
 	}
 	if !reflect.DeepEqual(data1, data2) || !strings.HasSuffix(string(data1), "\n") {
 		t.Fatal("Rust profile JSON is not deterministic newline-terminated output")
+	}
+	for _, forbidden := range []string{
+		`"version_predicates": null`,
+		`"else_flags": null`,
+		`"add": null`,
+		`"remove": null`,
+		`"else_add": null`,
+		`"else_remove": null`,
+	} {
+		if strings.Contains(string(data1), forbidden) {
+			t.Fatalf("Rust profile JSON contains %s:\n%s", forbidden, data1)
+		}
+	}
+}
+
+func TestRustProfileCoreEditionBoundaryAfterSkipFlags(t *testing.T) {
+	profile, err := GenerateRustProfile(rustProfileFixture(t, false), "x86")
+	if err != nil {
+		t.Fatalf("GenerateRustProfile() failed: %v", err)
+	}
+	core := rustProfileCrate(profile, "core")
+	for _, test := range []struct {
+		version string
+		want    string
+		absent  string
+	}{
+		{version: "1.78.0", want: "--edition=2021", absent: "--edition=2024"},
+		{version: "1.86.0", want: "--edition=2021", absent: "--edition=2024"},
+		{version: "1.87.0", want: "--edition=2024", absent: "--edition=2021"},
+	} {
+		t.Run(test.version, func(t *testing.T) {
+			flags := evaluateRustCrateFlags(t, profile, core, nil, test.version)
+			count := countRustProfileValue(flags, test.want)
+			if count != 1 {
+				t.Fatalf("flags %v contain %q %d times, want once", flags, test.want, count)
+			}
+			if containsRustProfileValue(flags, test.absent) {
+				t.Fatalf("flags %v unexpectedly contain %q", flags, test.absent)
+			}
+		})
+	}
+}
+
+func TestRustProfileVersionGateBoundaries(t *testing.T) {
+	x86, err := GenerateRustProfile(rustProfileFixture(t, false), "x86")
+	if err != nil {
+		t.Fatalf("GenerateRustProfile(x86) failed: %v", err)
+	}
+	arm64, err := GenerateRustProfile(rustProfileFixture(t, false), "arm64")
+	if err != nil {
+		t.Fatalf("GenerateRustProfile(arm64) failed: %v", err)
+	}
+
+	for _, test := range []struct {
+		name    string
+		profile *RustProfile
+		config  map[string]string
+		version string
+		want    string
+		absent  string
+	}{
+		{
+			name:    "arm64-target-before-1.85",
+			profile: arm64,
+			version: "1.84.0",
+			want:    "--target=aarch64-unknown-none",
+			absent:  "--target=aarch64-unknown-none-softfloat",
+		},
+		{
+			name:    "arm64-target-at-1.85",
+			profile: arm64,
+			version: "1.85.0",
+			want:    "--target=aarch64-unknown-none-softfloat",
+			absent:  "--target=aarch64-unknown-none",
+		},
+		{
+			name:    "x86-ibt-before-1.93",
+			profile: x86,
+			config:  map[string]string{"CONFIG_X86_KERNEL_IBT": "y"},
+			version: "1.92.0",
+			want:    "-Zno-jump-tables",
+			absent:  "-Cjump-tables=n",
+		},
+		{
+			name:    "x86-ibt-at-1.93",
+			profile: x86,
+			config:  map[string]string{"CONFIG_X86_KERNEL_IBT": "y"},
+			version: "1.93.0",
+			want:    "-Cjump-tables=n",
+			absent:  "-Zno-jump-tables",
+		},
+		{
+			name:    "frame-pointer-before-1.98",
+			profile: x86,
+			config:  map[string]string{"CONFIG_FRAME_POINTER": "y"},
+			version: "1.97.0",
+			want:    "-Zllvm_module_flag=frame-pointer:u32:2:max",
+		},
+		{
+			name:    "frame-pointer-at-1.98",
+			profile: x86,
+			config:  map[string]string{"CONFIG_FRAME_POINTER": "y"},
+			version: "1.98.0",
+			absent:  "-Zllvm_module_flag=frame-pointer:u32:2:max",
+		},
+		{
+			name:    "arm64-unwind-before-1.98",
+			profile: arm64,
+			config:  map[string]string{"CONFIG_UNWIND_TABLES": "y"},
+			version: "1.97.0",
+			want:    "-Zllvm_module_flag=uwtable:u32:2:max",
+		},
+		{
+			name:    "arm64-unwind-at-1.98",
+			profile: arm64,
+			config:  map[string]string{"CONFIG_UNWIND_TABLES": "y"},
+			version: "1.98.0",
+			absent:  "-Zllvm_module_flag=uwtable:u32:2:max",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			flags, predicates := evaluateRustTargetFlags(test.profile, test.config)
+			flags = applyRustProfilePredicates(t, flags, predicates, test.version)
+			if test.want != "" && !containsRustProfileValue(flags, test.want) {
+				t.Fatalf("flags %v do not contain %q", flags, test.want)
+			}
+			if test.absent != "" && containsRustProfileValue(flags, test.absent) {
+				t.Fatalf("flags %v unexpectedly contain %q", flags, test.absent)
+			}
+		})
 	}
 }
 
@@ -80,6 +258,94 @@ func TestGenerateRustProfilePinInitLayout(t *testing.T) {
 	}
 }
 
+func TestGenerateRustProfileArm64Layouts(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		arch       string
+		pinInit    bool
+		wantLayout string
+	}{
+		{name: "linux-6.12-legacy", arch: "arm64", wantLayout: "legacy"},
+		{name: "linux-6.18-pin-init", arch: "aarch64", pinInit: true, wantLayout: "pin-init"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := rustProfileFixture(t, test.pinInit)
+			profile, err := GenerateRustProfile(root, test.arch)
+			if err != nil {
+				t.Fatalf("GenerateRustProfile() failed: %v", err)
+			}
+			if profile.Architecture != "aarch64" || profile.SourceLayout != test.wantLayout {
+				t.Fatalf("profile identity = %#v", profile)
+			}
+			if profile.Target.Kind != "builtin" ||
+				profile.Target.BuiltinTriple != "aarch64-unknown-none" ||
+				profile.Target.GeneratorSource != "" ||
+				profile.Target.Stdin != "" ||
+				profile.Target.Output != "" {
+				t.Fatalf("arm64 target recipe = %#v", profile.Target)
+			}
+			for _, flag := range []string{"--target=aarch64-unknown-none", "-Ctarget-feature=-neon"} {
+				if !containsRustProfileValue(profile.TargetFlags.Always, flag) {
+					t.Fatalf("arm64 target flags %v do not contain %q", profile.TargetFlags.Always, flag)
+				}
+			}
+			if got, want := profile.TargetFlags.VersionPredicates, []RustVersionPredicate{newRustVersionPredicate(
+				"1.85.0",
+				[]string{"--target=aarch64-unknown-none-softfloat"},
+				[]string{"--target=aarch64-unknown-none", "-Ctarget-feature=-neon"},
+				nil,
+				[]string{"--target=aarch64-unknown-none-softfloat"},
+			)}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("arm64 target version predicates = %#v, want %#v", got, want)
+			}
+
+			unwind := rustProfileConditional(profile, "CONFIG_UNWIND_TABLES")
+			if got, want := unwind.Flags, []string{"-Cforce-unwind-tables=y", "-Zuse-sync-unwind=n"}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("arm64 unwind flags = %#v, want %#v", got, want)
+			}
+			if got, want := unwind.ElseFlags, []string{"-Cforce-unwind-tables=n"}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("arm64 no-unwind flags = %#v, want %#v", got, want)
+			}
+			if len(unwind.VersionPredicates) != 1 || unwind.VersionPredicates[0].AtLeast != "1.98.0" {
+				t.Fatalf("arm64 unwind version predicates = %#v", unwind.VersionPredicates)
+			}
+			ptrAuthIndex := rustProfileConditionalIndex(profile, "CONFIG_ARM64_PTR_AUTH_KERNEL")
+			btiIndex := rustProfileConditionalIndex(profile, "CONFIG_ARM64_BTI_KERNEL")
+			if btiIndex < 0 || ptrAuthIndex <= btiIndex {
+				t.Fatalf("arm64 branch-protection condition order = ptr-auth %d, BTI %d", ptrAuthIndex, btiIndex)
+			}
+			ptrAuth := profile.TargetFlags.Conditional[ptrAuthIndex]
+			if ptrAuth.UnlessConfig != "CONFIG_ARM64_BTI_KERNEL" {
+				t.Fatalf("arm64 pointer-auth condition guard = %q", ptrAuth.UnlessConfig)
+			}
+			if got := rustProfileConditional(profile, "CONFIG_SHADOW_CALL_STACK").Flags; !reflect.DeepEqual(got, []string{"-Zfixed-x18"}) {
+				t.Fatalf("arm64 shadow-call-stack flags = %#v", got)
+			}
+
+			core := rustProfileCrate(profile, "core")
+			for _, flag := range []string{
+				"__ashrti3=__rust__ashrti3",
+				"__ashlti3=__rust__ashlti3",
+				"__lshrti3=__rust__lshrti3",
+			} {
+				if !containsRustProfileValue(core.ObjcopyFlags, flag) {
+					t.Fatalf("arm64 core objcopy flags %v do not contain %q", core.ObjcopyFlags, flag)
+				}
+			}
+			if got, want := profile.UnsupportedConfigs, []string{
+				"CONFIG_CPU_BIG_ENDIAN",
+				"CONFIG_CFI",
+				"CONFIG_CFI_CLANG",
+				"CONFIG_KASAN",
+				"CONFIG_KCSAN",
+				"CONFIG_UBSAN",
+			}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("arm64 unsupported configs = %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
 func TestGenerateRustProfileRejectsMixedLayout(t *testing.T) {
 	root := rustProfileFixture(t, false)
 	writeRustProfileFixture(t, root, "rust/pin-init/src/lib.rs", "")
@@ -108,8 +374,8 @@ func TestGenerateRustProfileRejectsUnresolvedCommonFlag(t *testing.T) {
 
 func TestGenerateRustProfileRejectsOtherArchitectures(t *testing.T) {
 	root := rustProfileFixture(t, false)
-	_, err := GenerateRustProfile(root, "arm64")
-	if err == nil || !strings.Contains(err.Error(), "only x86_64") {
+	_, err := GenerateRustProfile(root, "riscv")
+	if err == nil || !strings.Contains(err.Error(), "only x86_64 and arm64") {
 		t.Fatalf("GenerateRustProfile() error = %v, want architecture error", err)
 	}
 }
@@ -133,7 +399,7 @@ KBUILD_RUSTFLAGS += -Coverflow-checks=$(if $(CONFIG_RUST_OVERFLOW_CHECKS),y,n)
 KBUILD_RUSTFLAGS-$(CONFIG_WERROR) += -Dwarnings
 ifdef CONFIG_FRAME_POINTER
 KBUILD_RUSTFLAGS += -Cforce-frame-pointers=y
-KBUILD_RUSTFLAGS += -Zllvm_module_flag=frame-pointer:u32:2:max
+KBUILD_RUSTFLAGS += $(if $(call rustc-min-version,109800),,-Zllvm_module_flag=frame-pointer:u32:2:max)
 endif
 `)
 	archMake := `
@@ -141,7 +407,7 @@ KBUILD_RUSTFLAGS += --target=$(objtree)/scripts/target.json
 KBUILD_RUSTFLAGS += -Ctarget-feature=-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2
 RETHUNK_RUSTFLAGS := -Zfunction-return=thunk-extern
 ifdef CONFIG_X86_KERNEL_IBT
-KBUILD_RUSTFLAGS += -Zcf-protection=branch -Cjump-tables=n
+KBUILD_RUSTFLAGS += -Zcf-protection=branch $(if $(call rustc-min-version,109300),-Cjump-tables=n,-Zno-jump-tables)
 endif
 ifdef CONFIG_CALL_PADDING
 PADDING_RUSTFLAGS := -Zpatchable-function-entry=$(CONFIG_FUNCTION_PADDING_BYTES),$(CONFIG_FUNCTION_PADDING_BYTES)
@@ -167,15 +433,54 @@ rustflags-$(CONFIG_GENERIC_CPU) += -Ztune-cpu=generic
 `
 	}
 	writeRustProfileFixture(t, root, "arch/x86/Makefile", archMake)
+	writeRustProfileFixture(t, root, "arch/arm64/Makefile", `
+ifeq ($(call rustc-min-version, 108500),y)
+KBUILD_RUSTFLAGS += --target=aarch64-unknown-none-softfloat
+else
+KBUILD_RUSTFLAGS += --target=aarch64-unknown-none -Ctarget-feature="-neon"
+endif
+ifneq ($(CONFIG_UNWIND_TABLES),y)
+KBUILD_RUSTFLAGS += -Cforce-unwind-tables=n
+else
+KBUILD_RUSTFLAGS += -Cforce-unwind-tables=y -Zuse-sync-unwind=n
+KBUILD_RUSTFLAGS += $(if $(call rustc-min-version,109800),,-Zllvm_module_flag=uwtable:u32:2:max)
+endif
+ifeq ($(CONFIG_ARM64_BTI_KERNEL),y)
+KBUILD_RUSTFLAGS += -Zbranch-protection=bti,pac-ret
+else ifeq ($(CONFIG_ARM64_PTR_AUTH_KERNEL),y)
+KBUILD_RUSTFLAGS += -Zbranch-protection=pac-ret
+endif
+ifeq ($(CONFIG_SHADOW_CALL_STACK), y)
+KBUILD_RUSTFLAGS += -Zfixed-x18
+endif
+`)
 	features := "arbitrary_self_types,lint_reasons,used_with_arg"
 	if pinInit {
 		features = "asm_const,asm_goto,arbitrary_self_types,lint_reasons,offset_of_nested,raw_ref_op,used_with_arg"
 	}
 	writeRustProfileFixture(t, root, "scripts/Makefile.build", "rust_allowed_features := "+features+"\n")
+	writeRustProfileFixture(t, root, "scripts/Makefile.debug", `
+ifdef CONFIG_DEBUG_INFO_DWARF5
+DEBUG_RUSTFLAGS += -Zdwarf-version=5
+endif
+ifdef CONFIG_DEBUG_INFO_REDUCED
+DEBUG_RUSTFLAGS += -Cdebuginfo=1
+else
+DEBUG_RUSTFLAGS += -Cdebuginfo=2
+endif
+`)
 	writeRustProfileFixture(t, root, "scripts/generate_rust_target.rs", `
+const RUSTC_VERSION: &str = "CONFIG_RUSTC_VERSION";
 fn main() {
     let cfg = KernelConfig::from_stdin();
-    if cfg.has("X86_64") {}
+    if cfg.has("ARM64") {
+        panic!("arm64 uses the builtin rustc aarch64-unknown-none target");
+    } else if cfg.has("X86_64") {
+        if cfg.rustc_version_atleast(1, 98, 0) {
+        } else if cfg.rustc_version_atleast(1, 86, 0) {
+        }
+        if cfg.rustc_version_atleast(1, 91, 0) {}
+    }
 }
 `)
 	rustMake := `
@@ -185,6 +490,10 @@ obj-$(CONFIG_RUST) += bindings.o kernel.o
 obj-$(CONFIG_RUST) += uapi.o
 obj-$(CONFIG_RUST) += exports.o
 redirect-intrinsics := __addsf3 __multi3
+ifneq ($(or $(CONFIG_ARM64),$(and $(CONFIG_RISCV),$(CONFIG_64BIT))),)
+redirect-intrinsics += __ashrti3 __ashlti3 __lshrti3
+endif
+core-edition := $(if $(call rustc-min-version,108700),2024,2021)
 cmd_rustc_procmacro = $(RUSTC) --crate-type proc-macro
 $(obj)/core.o: FORCE
 $(obj)/compiler_builtins.o: FORCE
@@ -269,4 +578,131 @@ func rustRuntimePaths(profile *RustProfile) []string {
 		paths[i] = object.Path
 	}
 	return paths
+}
+
+func hasRustConditionalFlag(conditions []RustConditionalFlags, config, flag string) bool {
+	for _, condition := range conditions {
+		if condition.Config != config {
+			continue
+		}
+		for _, got := range condition.Flags {
+			if got == flag {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func rustProfileConditional(profile *RustProfile, config string) RustConditionalFlags {
+	index := rustProfileConditionalIndex(profile, config)
+	if index < 0 {
+		return RustConditionalFlags{}
+	}
+	return profile.TargetFlags.Conditional[index]
+}
+
+func rustProfileConditionalIndex(profile *RustProfile, config string) int {
+	for i, condition := range profile.TargetFlags.Conditional {
+		if condition.Config == config {
+			return i
+		}
+	}
+	return -1
+}
+
+func containsRustProfileValue(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func countRustProfileValue(values []string, wanted string) int {
+	count := 0
+	for _, value := range values {
+		if value == wanted {
+			count++
+		}
+	}
+	return count
+}
+
+func evaluateRustCrateFlags(t *testing.T, profile *RustProfile, crate RustCrateProfile, config map[string]string, version string) []string {
+	t.Helper()
+	flags, predicates := evaluateRustTargetFlags(profile, config)
+	filtered := flags[:0]
+	for _, flag := range flags {
+		if !containsRustProfileValue(crate.SkipFlags, flag) {
+			filtered = append(filtered, flag)
+		}
+	}
+	filtered = append(filtered, crate.Flags...)
+	predicates = append(predicates, crate.VersionPredicates...)
+	return applyRustProfilePredicates(t, filtered, predicates, version)
+}
+
+func evaluateRustTargetFlags(profile *RustProfile, config map[string]string) ([]string, []RustVersionPredicate) {
+	flags := append([]string(nil), profile.CommonFlags.Always...)
+	flags = append(flags, profile.TargetFlags.Always...)
+	predicates := append([]RustVersionPredicate(nil), profile.CommonFlags.VersionPredicates...)
+	predicates = append(predicates, profile.TargetFlags.VersionPredicates...)
+	for _, condition := range profile.TargetFlags.Conditional {
+		if config[condition.Config] == condition.Equals {
+			flags = append(flags, condition.Flags...)
+			predicates = append(predicates, condition.VersionPredicates...)
+		} else {
+			flags = append(flags, condition.ElseFlags...)
+		}
+	}
+	return flags, predicates
+}
+
+func applyRustProfilePredicates(t *testing.T, flags []string, predicates []RustVersionPredicate, version string) []string {
+	t.Helper()
+	out := append([]string(nil), flags...)
+	for _, predicate := range predicates {
+		matches := rustProfileVersionAtLeast(t, version, predicate.AtLeast)
+		add, remove := predicate.ElseAdd, predicate.ElseRemove
+		if matches {
+			add, remove = predicate.Add, predicate.Remove
+		}
+		filtered := out[:0]
+		for _, flag := range out {
+			if !containsRustProfileValue(remove, flag) {
+				filtered = append(filtered, flag)
+			}
+		}
+		out = append(filtered, add...)
+	}
+	return out
+}
+
+func rustProfileVersionAtLeast(t *testing.T, version, minimum string) bool {
+	t.Helper()
+	parse := func(raw string) [3]int {
+		parts := strings.Split(raw, ".")
+		if len(parts) != 3 {
+			t.Fatalf("version %q does not use MAJOR.MINOR.PATCH", raw)
+		}
+		var out [3]int
+		for i, part := range parts {
+			value, err := strconv.Atoi(part)
+			if err != nil {
+				t.Fatalf("parse version %q: %v", raw, err)
+			}
+			out[i] = value
+		}
+		return out
+	}
+	got := parse(version)
+	want := parse(minimum)
+	for i := range got {
+		if got[i] != want[i] {
+			return got[i] > want[i]
+		}
+	}
+	return true
 }

--- a/internal/rusttoolchain/BUILD.bazel
+++ b/internal/rusttoolchain/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "rusttoolchain",
+    srcs = ["probe.go"],
+    importpath = "github.com/hermeticbuild/linux.bzl/internal/rusttoolchain",
+    visibility = ["//internal:__subpackages__"],
+)
+
+go_test(
+    name = "rusttoolchain_test",
+    srcs = ["probe_test.go"],
+    embed = [":rusttoolchain"],
+)

--- a/internal/rusttoolchain/probe.go
+++ b/internal/rusttoolchain/probe.go
@@ -1,0 +1,163 @@
+package rusttoolchain
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+const ProbeSchema = "linux-rust-toolchain-probe-v1"
+
+// Probe is the canonical identity of the rustc selected by Bazel toolchain
+// resolution. VersionCode fields use Linux's major*100000+minor*100+patch
+// encoding.
+type Probe struct {
+	Schema          string `json:"schema"`
+	VersionText     string `json:"version_text"`
+	Release         string `json:"release"`
+	Semver          string `json:"semver"`
+	Channel         string `json:"channel"`
+	CommitDate      string `json:"commit_date,omitempty"`
+	LLVMVersion     string `json:"llvm_version"`
+	VersionCode     int    `json:"version_code"`
+	LLVMVersionCode int    `json:"llvm_version_code"`
+}
+
+// ParseVerbose parses rustc -vV output.
+func ParseVerbose(output string) (Probe, error) {
+	values := map[string]string{}
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 || !strings.HasPrefix(lines[0], "rustc ") {
+		return Probe{}, fmt.Errorf("invalid rustc -vV output: missing rustc version line")
+	}
+	for _, line := range lines[1:] {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		values[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	release := values["release"]
+	if release == "" {
+		release = strings.TrimSpace(strings.TrimPrefix(lines[0], "rustc "))
+		if index := strings.IndexByte(release, ' '); index >= 0 {
+			release = release[:index]
+		}
+	}
+	semver, channel, versionCode, err := ParseRelease(release)
+	if err != nil {
+		return Probe{}, err
+	}
+	llvmVersion := values["LLVM version"]
+	llvmVersionCode, err := ParseLLVMVersionCode(llvmVersion)
+	if err != nil {
+		return Probe{}, fmt.Errorf("invalid rustc LLVM version %q: %w", llvmVersion, err)
+	}
+	return Probe{
+		Schema:          ProbeSchema,
+		VersionText:     lines[0],
+		Release:         release,
+		Semver:          semver,
+		Channel:         channel,
+		CommitDate:      values["commit-date"],
+		LLVMVersion:     llvmVersion,
+		VersionCode:     versionCode,
+		LLVMVersionCode: llvmVersionCode,
+	}, nil
+}
+
+// ParseRelease returns the stable semver prefix, channel, and Linux version
+// code for a rustc release such as 1.98.0-nightly.
+func ParseRelease(release string) (string, string, int, error) {
+	semver, suffix, _ := strings.Cut(release, "-")
+	channel := "stable"
+	if suffix != "" {
+		channel = strings.SplitN(suffix, ".", 2)[0]
+	}
+	code, err := ParseVersionCode(semver)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid rustc release %q: %w", release, err)
+	}
+	return semver, channel, code, nil
+}
+
+func ParseVersionCode(version string) (int, error) {
+	return parseVersionCode(version, 100000, 999)
+}
+
+func ParseLLVMVersionCode(version string) (int, error) {
+	return parseVersionCode(version, 10000, 99)
+}
+
+func parseVersionCode(version string, majorScale, maximumMinor int) (int, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0, fmt.Errorf("expected MAJOR.MINOR[.PATCH]")
+	}
+	numbers := []int{0, 0, 0}
+	for i, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil || value < 0 {
+			return 0, fmt.Errorf("invalid numeric component %q", part)
+		}
+		numbers[i] = value
+	}
+	if numbers[1] > maximumMinor || numbers[2] > 99 {
+		return 0, fmt.Errorf("version component exceeds Linux encoding")
+	}
+	return numbers[0]*majorScale + numbers[1]*100 + numbers[2], nil
+}
+
+func (p Probe) Validate() error {
+	if p.Schema != ProbeSchema {
+		return fmt.Errorf("unsupported Rust toolchain probe schema %q", p.Schema)
+	}
+	versionFields := strings.Fields(p.VersionText)
+	if len(versionFields) < 2 || versionFields[0] != "rustc" || versionFields[1] != p.Release {
+		return fmt.Errorf("invalid rustc version text %q for release %q", p.VersionText, p.Release)
+	}
+	semver, channel, code, err := ParseRelease(p.Release)
+	if err != nil {
+		return err
+	}
+	llvmCode, err := ParseLLVMVersionCode(p.LLVMVersion)
+	if err != nil {
+		return fmt.Errorf("invalid LLVM version: %w", err)
+	}
+	if p.Semver != semver || p.Channel != channel || p.VersionCode != code || p.LLVMVersionCode != llvmCode {
+		return fmt.Errorf("inconsistent Rust toolchain probe")
+	}
+	return nil
+}
+
+func (p Probe) AtLeast(version string) (bool, error) {
+	minimum, err := ParseVersionCode(version)
+	if err != nil {
+		return false, err
+	}
+	return p.VersionCode >= minimum, nil
+}
+
+func Decode(r io.Reader) (Probe, error) {
+	var probe Probe
+	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&probe); err != nil {
+		return Probe{}, err
+	}
+	if err := probe.Validate(); err != nil {
+		return Probe{}, err
+	}
+	return probe, nil
+}
+
+func Encode(w io.Writer, probe Probe) error {
+	if err := probe.Validate(); err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(probe)
+}

--- a/internal/rusttoolchain/probe_test.go
+++ b/internal/rusttoolchain/probe_test.go
@@ -1,0 +1,89 @@
+package rusttoolchain
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestParseVerboseNightly(t *testing.T) {
+	probe, err := ParseVerbose(`rustc 1.98.0-nightly (012345678 2026-06-23)
+binary: rustc
+commit-hash: 0123456789
+commit-date: 2026-06-23
+host: x86_64-unknown-linux-gnu
+release: 1.98.0-nightly
+LLVM version: 22.1.7
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if probe.Semver != "1.98.0" || probe.Channel != "nightly" || probe.VersionCode != 109800 {
+		t.Fatalf("unexpected rustc identity: %#v", probe)
+	}
+	if probe.VersionText != "rustc 1.98.0-nightly (012345678 2026-06-23)" {
+		t.Fatalf("version text = %q", probe.VersionText)
+	}
+	if probe.LLVMVersionCode != 220107 || probe.CommitDate != "2026-06-23" {
+		t.Fatalf("unexpected rustc details: %#v", probe)
+	}
+}
+
+func TestParseVerboseStable(t *testing.T) {
+	probe, err := ParseVerbose(`rustc 1.78.0 (9b00956e5 2024-04-29)
+release: 1.78.0
+LLVM version: 18.1.2
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if probe.Channel != "stable" || probe.VersionCode != 107800 {
+		t.Fatalf("unexpected stable identity: %#v", probe)
+	}
+	atLeast, err := probe.AtLeast("1.78.0")
+	if err != nil || !atLeast {
+		t.Fatalf("AtLeast() = %v, %v", atLeast, err)
+	}
+}
+
+func TestProbeRoundTrip(t *testing.T) {
+	probe, err := ParseVerbose(`rustc 1.97.0 (abc 2026-03-01)
+release: 1.97.0
+LLVM version: 22.1.6
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var encoded bytes.Buffer
+	if err := Encode(&encoded, probe); err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := Decode(strings.NewReader(encoded.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded != probe {
+		t.Fatalf("round trip = %#v, want %#v", decoded, probe)
+	}
+}
+
+func TestParseVerboseRejectsMissingLLVM(t *testing.T) {
+	_, err := ParseVerbose("rustc 1.78.0\nrelease: 1.78.0\n")
+	if err == nil {
+		t.Fatal("ParseVerbose() succeeded without LLVM version")
+	}
+}
+
+func TestProbeRejectsMismatchedVersionText(t *testing.T) {
+	probe, err := ParseVerbose(`rustc 1.98.0-nightly (012345678 2026-06-23)
+release: 1.98.0-nightly
+LLVM version: 22.1.7
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	probe.VersionText = "rustc 1.97.0"
+	if err := probe.Validate(); err == nil {
+		t.Fatal("Probe.Validate() accepted version text for another release")
+	}
+}


### PR DESCRIPTION
## Summary

- upgrade the independent kconfig tool protocol to emit `linux-rust-profile-v2` for x86_64 and arm64
- accept and validate the exact selected Rust toolchain probe during action-time config resolution
- preserve module roots and `OBJECT_FILES_NON_STANDARD` metadata and emit the source-built x86 objtool label
- keep the checked-in consumer prebuilt pin at v0.0.13

This is deliberately only the source release change. It does not change `linux.bzl`, repository rules, module dependencies, workflows, release URLs, Aya, or the prebuilt integrity table. The consumer-owned Rust toolchain PR will pin v0.0.14 only after this change is merged, tagged in `hermeticbuild/linux.bzl`, and all six official assets are published.

## Validation

- `go test ./internal/kconfig ./internal/rusttoolchain ./internal/cmd/kconfig ./internal/cmd/kconfig_parse`
- repository Buildifier test
- `git diff --check`

The existing `kconfig prebuilts` pull-request workflow builds the exact release target for Linux, macOS, and Windows on amd64 and arm64.

## Release order

1. Merge this PR.
2. On the merged commit, run `VERSION=v0.0.14 ./release_kconfig.sh` with upstream write access.
3. Verify the six release assets and their integrity metadata.
4. Pin v0.0.14 in the separate consumer PR.