### PR TITLE
Optimize compact metadata generation

### DIFF
--- a/internal/cmd/kconfig_parse/main.go
+++ b/internal/cmd/kconfig_parse/main.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
@@ -157,7 +160,64 @@ func syntheticKconfigRoot(root string, extras []namedPath) (string, func(), erro
 	return file.Name(), cleanup, nil
 }
 
+func startRuntimeProfiles(cpuPath, heapPath, allocsPath string) (func() error, error) {
+	var cpuFile *os.File
+	if cpuPath != "" {
+		var err error
+		cpuFile, err = os.Create(cpuPath)
+		if err != nil {
+			return nil, fmt.Errorf("create CPU profile: %w", err)
+		}
+		if err := pprof.StartCPUProfile(cpuFile); err != nil {
+			cpuFile.Close()
+			return nil, fmt.Errorf("start CPU profile: %w", err)
+		}
+	}
+
+	return func() error {
+		var profileErrors []error
+		if cpuFile != nil {
+			pprof.StopCPUProfile()
+			if err := cpuFile.Close(); err != nil {
+				profileErrors = append(profileErrors, fmt.Errorf("close CPU profile: %w", err))
+			}
+		}
+		for _, profile := range []struct {
+			name string
+			path string
+			gc   bool
+		}{
+			{name: "allocs", path: allocsPath},
+			{name: "heap", path: heapPath, gc: true},
+		} {
+			name, path := profile.name, profile.path
+			if path == "" {
+				continue
+			}
+			if profile.gc {
+				runtime.GC()
+			}
+			file, err := os.Create(path)
+			if err != nil {
+				profileErrors = append(profileErrors, fmt.Errorf("create %s profile: %w", name, err))
+				continue
+			}
+			if err := pprof.Lookup(name).WriteTo(file, 0); err != nil {
+				profileErrors = append(profileErrors, fmt.Errorf("write %s profile: %w", name, err))
+			}
+			if err := file.Close(); err != nil {
+				profileErrors = append(profileErrors, fmt.Errorf("close %s profile: %w", name, err))
+			}
+		}
+		return errors.Join(profileErrors...)
+	}, nil
+}
+
 func main() {
+	os.Exit(run())
+}
+
+func run() (exitCode int) {
 	var (
 		root                     = flag.String("root", "", "Root Kconfig file to parse")
 		srctree                  = flag.String("srctree", "", "Source tree used to resolve source statements")
@@ -223,6 +283,9 @@ func main() {
 		sourceTreeLookupFiles    = stringSliceFlag{}
 		sourceTreeScriptsHeaders = stringSliceFlag{}
 		sourceTreeUapiHeaders    = stringSliceFlag{}
+		cpuProfile               = flag.String("cpu_profile", "", "Optional path to write a Go CPU profile")
+		heapProfile              = flag.String("heap_profile", "", "Optional path to write a Go live-heap profile")
+		allocsProfile            = flag.String("allocs_profile", "", "Optional path to write a Go cumulative-allocation profile")
 	)
 	flag.Var(vars, "var", "Preprocessor variable in KEY=VALUE form. May be repeated")
 	flag.Var(env, "env", "Hermetic environment variable in KEY=VALUE form. May be repeated")
@@ -249,15 +312,29 @@ func main() {
 	flag.Var(&sourceTreeUapiHeaders, "source_tree_uapi_headers_label", "Bazel label for UAPI headers emitted into source-backed compact object rules. May be repeated")
 	flag.Parse()
 
+	stopProfiles, err := startRuntimeProfiles(*cpuProfile, *heapProfile, *allocsProfile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start runtime profiles: %v\n", err)
+		return 2
+	}
+	defer func() {
+		if err := stopProfiles(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to finish runtime profiles: %v\n", err)
+			if exitCode == 0 {
+				exitCode = 1
+			}
+		}
+	}()
+
 	compactSchema, err := kconfig.ParseCompactSchema(*compactSchemaValue)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(2)
+		return 2
 	}
 
 	if *root == "" && *kbuildOut == "" && *kbuildTreeOut == "" && *rustProfileOut == "" {
 		flag.PrintDefaults()
-		os.Exit(2)
+		return 2
 	}
 
 	var tree *kconfig.Tree
@@ -266,7 +343,7 @@ func main() {
 		shell, err := linuxProbeShell(*linuxProbeModel, linuxProbeValues)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to configure Linux probe model: %v\n", err)
-			os.Exit(2)
+			return 2
 		}
 		sourceRoots := namedPathMap(sourceRootMaps)
 		resolvedRoot := *root
@@ -278,7 +355,7 @@ func main() {
 			synthetic, cleanup, err := syntheticKconfigRoot(resolvedRoot, kconfigExtras)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to write synthetic Kconfig root: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 			defer cleanup()
 			resolvedRoot = synthetic
@@ -293,36 +370,36 @@ func main() {
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to parse Kconfig: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 	}
 
 	if *kbuildOut != "" {
 		if *kbuildPath == "" {
 			fmt.Fprintf(os.Stderr, "-kbuild is required when -kbuild_out is set\n")
-			os.Exit(2)
+			return 2
 		}
 		kb, err := parseKbuild(*kbuildPath, *kbuildRecursive, *kbuildSrctree, *srctree, vars)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to parse Kbuild: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		data, err := json.MarshalIndent(kb, "", "  ")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to encode Kbuild dump: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		data = append(data, '\n')
 		if err := os.WriteFile(workspacePath(*kbuildOut), data, 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write Kbuild dump: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 	}
 
 	if *kbuildTreeOut != "" {
 		if *kbuildTreeRoot == "" {
 			fmt.Fprintf(os.Stderr, "-kbuild_tree_root is required when -kbuild_tree_out is set\n")
-			os.Exit(2)
+			return 2
 		}
 		resolvedRoot := workspacePath(*kbuildTreeRoot)
 		treeVars := map[string]string{}
@@ -335,53 +412,53 @@ func main() {
 		summary, err := validateKbuildTree(resolvedRoot, kbuildTreeExcludes, treeVars)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to validate Kbuild tree: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		if summary.Count < *kbuildTreeMinCount {
 			fmt.Fprintf(os.Stderr, "failed to validate Kbuild tree: parsed %d files, want at least %d\n", summary.Count, *kbuildTreeMinCount)
-			os.Exit(1)
+			return 1
 		}
 		data, err := json.MarshalIndent(summary, "", "  ")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to encode Kbuild tree summary: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		data = append(data, '\n')
 		if err := os.WriteFile(workspacePath(*kbuildTreeOut), data, 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write Kbuild tree summary: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 	}
 
 	if *rustProfileOut != "" {
 		if compactSchema != kconfig.CompactSchemaV012 && compactSchema != kconfig.CompactSchemaV013 {
 			fmt.Fprintln(os.Stderr, "-rust_profile_out requires -compact_schema=v0.0.12 or v0.0.13")
-			os.Exit(2)
+			return 2
 		}
 		if *srctree == "" {
 			fmt.Fprintln(os.Stderr, "-srctree is required for -rust_profile_out")
-			os.Exit(2)
+			return 2
 		}
 		profile, err := kconfig.GenerateRustProfile(workspacePath(*srctree), vars["ARCH"])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to generate Rust profile: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		data, err := profile.JSON()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to encode Rust profile: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		if err := os.WriteFile(workspacePath(*rustProfileOut), data, 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write Rust profile: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 	}
 
 	resolvedConfigRequested := *resolveConfig != "" || *resolvedConfigOut != "" || *resolvedAutoConfOut != "" || *resolvedCmdOut != "" || *resolvedAutoconfOut != "" || *resolvedRustcCfgOut != "" || *resolvedReleaseOut != ""
 	if tree == nil && (*compactMetadataOut != "" || *objectBuildfileOut != "" || *imageBuildfileOut != "" || resolvedConfigRequested || *resolvedFlagsOut != "" || *out != "") {
 		fmt.Fprintf(os.Stderr, "-root is required for Kconfig outputs\n")
-		os.Exit(2)
+		return 2
 	}
 
 	if resolvedConfigRequested {
@@ -394,14 +471,14 @@ func main() {
 			kernelRelease: *resolvedReleaseOut,
 		}, *kernelVersion); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write resolved config: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 	}
 
 	if *resolvedFlagsOut != "" {
 		if err := writeResolvedFlags(tree, *resolveConfig, *resolveOverlay, *configMode, *resolvedFlagsOut); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write resolved flags: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 	}
 
@@ -414,7 +491,7 @@ func main() {
 		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to configure compact generated headers: %v\n", err)
-			os.Exit(2)
+			return 2
 		}
 		metadata, err := compactMetadata(
 			tree,
@@ -434,17 +511,17 @@ func main() {
 		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to generate compact metadata: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 		if *compactMetadataOut != "" {
 			data, err := metadata.JSON()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to encode compact metadata: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 			if err := os.WriteFile(workspacePath(*compactMetadataOut), data, 0o644); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to write compact metadata: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 		}
 		if *objectBuildfileOut != "" {
@@ -475,11 +552,11 @@ func main() {
 			})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to generate compact object BUILD file: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 			if err := os.WriteFile(workspacePath(*objectBuildfileOut), data, 0o644); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to write compact object BUILD file: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 		}
 		if *imageBuildfileOut != "" {
@@ -498,11 +575,11 @@ func main() {
 			})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to generate compact image BUILD file: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 			if err := os.WriteFile(workspacePath(*imageBuildfileOut), data, 0o644); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to write compact image BUILD file: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 		}
 		if *compactBuildfileOut != "" {
@@ -533,7 +610,7 @@ func main() {
 			})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to generate compact object BUILD file: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 			objectPkg := *objectLabelPackage
 			if objectPkg == "" {
@@ -550,7 +627,7 @@ func main() {
 			})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to generate compact image BUILD file: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 			exports := []string(compactExports)
 			if len(exports) == 0 {
@@ -559,11 +636,11 @@ func main() {
 			data, err := kconfig.MergeBuildFiles("compact.BUILD.bazel", exports, objectBuild, imageBuild)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to merge compact BUILD file: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 			if err := os.WriteFile(workspacePath(*compactBuildfileOut), data, 0o644); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to write compact BUILD file: %v\n", err)
-				os.Exit(1)
+				return 1
 			}
 		}
 	}
@@ -571,27 +648,28 @@ func main() {
 	// Only emit the JSON dump when explicitly requested, or when no output was
 	// requested at all (preserves the prior default of dumping to stdout).
 	if *out == "" && (*kbuildOut != "" || *kbuildTreeOut != "" || *compactMetadataOut != "" || *compactBuildfileOut != "" || *objectBuildfileOut != "" || *imageBuildfileOut != "" || *rustProfileOut != "" || resolvedConfigRequested || *resolvedFlagsOut != "") {
-		return
+		return 0
 	}
 
 	data, err := json.MarshalIndent(tree.Dump(), "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to encode Kconfig dump: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 	data = append(data, '\n')
 
 	if *out == "" {
 		if _, err := os.Stdout.Write(data); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write stdout: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
-		return
+		return 0
 	}
 	if err := os.WriteFile(workspacePath(*out), data, 0o644); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write output: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
 func linuxProbeShell(model string, values map[string]string) (func(context.Context, string) (string, error), error) {
@@ -1069,18 +1147,11 @@ func compactMetadata(
 			return nil, fmt.Errorf("create resolved flags dir: %w", err)
 		}
 	}
-	parts := make([]*kconfig.CompactMetadata, 0, len(configs))
-	for _, config := range configs {
-		resolved, err := tree.ResolveConfigWithOptions(config.Name, config.Flags, kconfig.ResolveConfigOptions{
-			AllNoConfig: config.AllNoConfig,
-		})
-		if err != nil {
-			return nil, err
-		}
+	return tree.CompactMetadataBatchWithOptions(configs, opts, func(resolved *kconfig.ResolvedConfig) (*kconfig.KbuildFile, string, error) {
 		if resolvedFlagsDir != "" {
-			flagsPath := filepath.Join(workspacePath(resolvedFlagsDir), config.Name+".flags")
+			flagsPath := filepath.Join(workspacePath(resolvedFlagsDir), resolved.Name+".flags")
 			if err := os.WriteFile(flagsPath, []byte(strings.Join(resolvedFlagLines(resolved), "\n")+"\n"), 0o644); err != nil {
-				return nil, fmt.Errorf("write resolved flags for %s: %w", config.Name, err)
+				return nil, "", fmt.Errorf("write resolved flags for %s: %w", resolved.Name, err)
 			}
 		}
 		kbuildOpts := kconfig.KbuildOptions{
@@ -1096,7 +1167,7 @@ func compactMetadata(
 			kb, parseErr = kconfig.ParseKbuildFileWithOptions(workspacePath(kbuildPath), kbuildOpts)
 		}
 		if parseErr != nil {
-			return nil, parseErr
+			return nil, "", parseErr
 		}
 		for _, extra := range kbuildExtras {
 			extraRoot := sourceRoots[extra.Name]
@@ -1109,19 +1180,12 @@ func compactMetadata(
 				MaxIncludeDepth: 64,
 			})
 			if err != nil {
-				return nil, err
+				return nil, "", err
 			}
 			kb = kconfig.MergeKbuildFileAtDirectory(kb, extra.Name, kconfig.PrefixKbuildFile(extraKb, extra.Name))
 		}
-		configOpts := opts
-		configOpts.GeneratedHeadersLabel = generatedHeadersByConfig[config.Name]
-		part, err := tree.CompactMetadataWithOptions(kb, []kconfig.NamedConfig{config}, configOpts)
-		if err != nil {
-			return nil, err
-		}
-		parts = append(parts, part)
-	}
-	return kconfig.MergeCompactMetadata(parts...)
+		return kb, generatedHeadersByConfig[resolved.Name], nil
+	})
 }
 
 func kbuildLibraryDirs(vars map[string]string) []string {

--- a/internal/cmd/kconfig_parse/main_test.go
+++ b/internal/cmd/kconfig_parse/main_test.go
@@ -1,11 +1,42 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/hermeticbuild/linux.bzl/internal/kconfig"
 )
+
+func TestStartRuntimeProfilesWritesMemoryProfiles(t *testing.T) {
+	dir := t.TempDir()
+	heapPath := filepath.Join(dir, "heap.pprof")
+	allocsPath := filepath.Join(dir, "allocs.pprof")
+	stop, err := startRuntimeProfiles("", heapPath, allocsPath)
+	if err != nil {
+		t.Fatalf("startRuntimeProfiles() failed: %v", err)
+	}
+	if err := stop(); err != nil {
+		t.Fatalf("stop profiles failed: %v", err)
+	}
+	for _, path := range []string{heapPath, allocsPath} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("Stat(%q) failed: %v", path, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("profile %q is empty", path)
+		}
+	}
+}
+
+func TestStartRuntimeProfilesRejectsInvalidCPUPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "cpu.pprof")
+	if _, err := startRuntimeProfiles(path, "", ""); err == nil {
+		t.Fatalf("startRuntimeProfiles(%q) succeeded, want an error", path)
+	}
+}
 
 func TestKbuildVariablesForConfigUsesWrittenConfigView(t *testing.T) {
 	vars := kbuildVariablesForConfig(

--- a/internal/kconfig/compact.go
+++ b/internal/kconfig/compact.go
@@ -307,6 +307,29 @@ func MergeCompactMetadata(parts ...*CompactMetadata) (*CompactMetadata, error) {
 }
 
 func (t *Tree) CompactMetadataWithOptions(kb *KbuildFile, configs []NamedConfig, opts CompactMetadataOptions) (*CompactMetadata, error) {
+	return t.compactMetadataBatchWithOptions(configs, opts, func(*ResolvedConfig) (*KbuildFile, string, error) {
+		return kb, opts.GeneratedHeadersLabel, nil
+	})
+}
+
+// CompactMetadataBatchWithOptions resolves and emits multiple config-specific
+// Kbuild graphs while sharing immutable source scanning work for the invocation.
+func (t *Tree) CompactMetadataBatchWithOptions(
+	configs []NamedConfig,
+	opts CompactMetadataOptions,
+	kbuildForConfig func(*ResolvedConfig) (*KbuildFile, string, error),
+) (*CompactMetadata, error) {
+	if kbuildForConfig == nil {
+		return nil, fmt.Errorf("compact metadata Kbuild resolver must not be nil")
+	}
+	return t.compactMetadataBatchWithOptions(configs, opts, kbuildForConfig)
+}
+
+func (t *Tree) compactMetadataBatchWithOptions(
+	configs []NamedConfig,
+	opts CompactMetadataOptions,
+	kbuildForConfig func(*ResolvedConfig) (*KbuildFile, string, error),
+) (*CompactMetadata, error) {
 	if opts.Schema.isV013() && strings.TrimSpace(opts.CompileEnvironmentABI) == "" {
 		return nil, fmt.Errorf("compact schema %s requires a non-empty compile environment ABI", opts.Schema)
 	}
@@ -327,9 +350,9 @@ func (t *Tree) CompactMetadataWithOptions(kb *KbuildFile, configs []NamedConfig,
 	}
 	seenConfigs := map[string]bool{}
 	seenImageTargets := map[string]string{}
-	var scanner *configSourceScanner
+	var sourceCache *compactSourceCache
 	if opts.Schema.isV012() {
-		scanner = newConfigSourceScanner(opts)
+		sourceCache = newCompactSourceCache()
 	}
 	for _, named := range configs {
 		if named.Name == "" {
@@ -346,12 +369,23 @@ func (t *Tree) CompactMetadataWithOptions(kb *KbuildFile, configs []NamedConfig,
 		if err != nil {
 			return nil, err
 		}
+		kb, generatedHeadersLabel, err := kbuildForConfig(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("resolve Kbuild for config %q: %w", named.Name, err)
+		}
+		if kb == nil {
+			return nil, fmt.Errorf("resolve Kbuild for config %q: nil Kbuild", named.Name)
+		}
+		var scanner *configSourceScanner
+		if sourceCache != nil {
+			scanner = newConfigSourceScannerWithCache(opts, sourceCache)
+		}
 		fullConfigPayload := CompactConfigPayload{}
 		headerGroupID := ""
 		if opts.Schema.isV013() {
 			fullConfigPayload = newCompactConfigPayload(compactFullConfigFragment(resolved))
 			configPayloads[fullConfigPayload.ID] = fullConfigPayload
-			if opts.GeneratedHeadersLabel != "" {
+			if generatedHeadersLabel != "" {
 				headerFragment, headerInputs, footprint, err := generatedHeaderFootprint(resolved, opts, scanner)
 				if err != nil {
 					return nil, fmt.Errorf("derive generated headers for config %q: %w", named.Name, err)
@@ -360,7 +394,7 @@ func (t *Tree) CompactMetadataWithOptions(kb *KbuildFile, configs []NamedConfig,
 				configPayloads[headerConfigPayload.ID] = headerConfigPayload
 				group := newCompactHeaderGroup(
 					headerConfigPayload.ID,
-					opts.GeneratedHeadersLabel,
+					generatedHeadersLabel,
 					opts.Srcarch,
 					footprint,
 					headerInputs,
@@ -491,7 +525,6 @@ func (t *Tree) CompactMetadataWithOptions(kb *KbuildFile, configs []NamedConfig,
 			return nil, err
 		}
 	}
-	sort.Slice(out.Configs, func(i, j int) bool { return out.Configs[i].Name < out.Configs[j].Name })
 	if err := out.validateContentIDs(); err != nil {
 		return nil, err
 	}
@@ -1688,7 +1721,7 @@ func (o resolvedKbuildObject) variant(
 			sourceInputs = nil
 		}
 	}
-	targetHash := objectVariantHash(o.object, o.mode, modname, flags, remove, fragment, sourceIncludes, deps, members)
+	targetHash := ""
 	contentID := ""
 	compileEnvironmentID := ""
 	if schema.isV013() {
@@ -1714,6 +1747,8 @@ func (o resolvedKbuildObject) variant(
 			compileEnvironmentABI,
 		)
 		targetHash = compactShortID(contentID)
+	} else {
+		targetHash = objectVariantHash(o.object, o.mode, modname, flags, remove, fragment, sourceIncludes, deps, members)
 	}
 	return CompactObjectVariant{
 		Target:             sanitizeTargetName(strings.TrimSuffix(o.object, ".o")) + "__" + targetHash,

--- a/internal/kconfig/compact_content.go
+++ b/internal/kconfig/compact_content.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"reflect"
 	"sort"
 	"strconv"
@@ -18,15 +19,35 @@ const (
 	compactShortIDLength            = 24
 )
 
-func compactContentID(domain string, values ...string) string {
-	hash := sha256.New()
-	hash.Write([]byte(domain))
-	hash.Write([]byte{0})
-	for _, value := range values {
-		hash.Write([]byte(value))
-		hash.Write([]byte{0})
+var compactContentSeparator = []byte{0}
+
+type compactContentHasher struct {
+	hash hash.Hash
+}
+
+func newCompactContentHasher(domain string) *compactContentHasher {
+	hasher := &compactContentHasher{hash: sha256.New()}
+	hasher.writeValue(domain)
+	return hasher
+}
+
+func (h *compactContentHasher) writeValue(parts ...string) {
+	for _, part := range parts {
+		_, _ = h.hash.Write([]byte(part))
 	}
-	return hex.EncodeToString(hash.Sum(nil))
+	_, _ = h.hash.Write(compactContentSeparator)
+}
+
+func (h *compactContentHasher) id() string {
+	return hex.EncodeToString(h.hash.Sum(nil))
+}
+
+func compactContentID(domain string, values ...string) string {
+	hasher := newCompactContentHasher(domain)
+	for _, value := range values {
+		hasher.writeValue(value)
+	}
+	return hasher.id()
 }
 
 func compactShortID(id string) string {
@@ -114,30 +135,29 @@ func objectVariantContentID(
 	memberContentIDs []string,
 	abi string,
 ) string {
-	values := []string{
-		"object=" + object,
-		"mode=" + mode,
-		"modname=" + modname,
-		"compile_environment=" + compileEnvironmentID,
-		"abi=" + abi,
-		"source=" + source,
-	}
+	hasher := newCompactContentHasher(compactObjectContentDomain)
+	hasher.writeValue("object=", object)
+	hasher.writeValue("mode=", mode)
+	hasher.writeValue("modname=", modname)
+	hasher.writeValue("compile_environment=", compileEnvironmentID)
+	hasher.writeValue("abi=", abi)
+	hasher.writeValue("source=", source)
 	for _, flag := range flags {
-		values = append(values, "flag="+flag)
+		hasher.writeValue("flag=", flag)
 	}
 	for _, flag := range removeFlags {
-		values = append(values, "remove_flag="+flag)
+		hasher.writeValue("remove_flag=", flag)
 	}
 	for _, input := range sourceInputs {
-		values = append(values, "source_input="+input.Path+"\x00"+input.Digest)
+		hasher.writeValue("source_input=", input.Path, "\x00", input.Digest)
 	}
 	for _, contentID := range depContentIDs {
-		values = append(values, "dep_content_id="+contentID)
+		hasher.writeValue("dep_content_id=", contentID)
 	}
 	for _, contentID := range memberContentIDs {
-		values = append(values, "member_content_id="+contentID)
+		hasher.writeValue("member_content_id=", contentID)
 	}
-	return compactContentID(compactObjectContentDomain, values...)
+	return hasher.id()
 }
 
 func compactCompileEnvironmentValue(environment CompactCompileEnvironment) string {

--- a/internal/kconfig/compact_test.go
+++ b/internal/kconfig/compact_test.go
@@ -2,6 +2,8 @@ package kconfig
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1158,6 +1160,100 @@ func TestCompactV013ObjectBuildUsesOneExactCompileEnvironmentIndex(t *testing.T)
 	}
 }
 
+func TestCompactMetadataBatchMatchesMergedConfigGraphs(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	parseKbuild := func(name, content string) *KbuildFile {
+		t.Helper()
+		kb, err := ParseKbuild(strings.NewReader(content), name)
+		if err != nil {
+			t.Fatalf("ParseKbuild(%s) failed: %v", name, err)
+		}
+		return kb
+	}
+	baseKbuild := parseKbuild("base/Kbuild", "obj-y += init.o\n")
+	debugKbuild := parseKbuild("debug/Kbuild", "obj-y += init.o debug.o\n")
+	sourceRoot := t.TempDir()
+	writeCompactSource(t, sourceRoot, "init.c")
+	writeCompactSource(t, sourceRoot, "debug.c")
+	writeCompactV013ForcedInputs(t, sourceRoot)
+
+	configs := []NamedConfig{
+		{Name: "debug", Flags: map[string]string{"CONFIG_DEBUG": "y"}},
+		{Name: "base"},
+	}
+	opts := CompactMetadataOptions{
+		Schema:                CompactSchemaV013,
+		SourceRoot:            sourceRoot,
+		CompileEnvironmentABI: "object-abi-v1",
+	}
+	labels := map[string]string{
+		"base":  "//headers:base",
+		"debug": "//headers:debug",
+	}
+	kbuilds := map[string]*KbuildFile{
+		"base":  baseKbuild,
+		"debug": debugKbuild,
+	}
+
+	var singles []*CompactMetadata
+	for _, config := range configs {
+		configOpts := opts
+		configOpts.GeneratedHeadersLabel = labels[config.Name]
+		part, err := tree.CompactMetadataWithOptions(kbuilds[config.Name], []NamedConfig{config}, configOpts)
+		if err != nil {
+			t.Fatalf("CompactMetadataWithOptions(%s) failed: %v", config.Name, err)
+		}
+		singles = append(singles, part)
+	}
+	merged, err := MergeCompactMetadata(singles...)
+	if err != nil {
+		t.Fatalf("MergeCompactMetadata() failed: %v", err)
+	}
+
+	var calls []string
+	batch, err := tree.CompactMetadataBatchWithOptions(configs, opts, func(config *ResolvedConfig) (*KbuildFile, string, error) {
+		calls = append(calls, config.Name)
+		return kbuilds[config.Name], labels[config.Name], nil
+	})
+	if err != nil {
+		t.Fatalf("CompactMetadataBatchWithOptions() failed: %v", err)
+	}
+	if want := []string{"debug", "base"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("Kbuild callback calls = %v, want %v", calls, want)
+	}
+	gotJSON, err := batch.JSON()
+	if err != nil {
+		t.Fatalf("batch.JSON() failed: %v", err)
+	}
+	wantJSON, err := merged.JSON()
+	if err != nil {
+		t.Fatalf("merged.JSON() failed: %v", err)
+	}
+	if !reflect.DeepEqual(gotJSON, wantJSON) {
+		t.Fatalf("batch metadata differs from merged single-config metadata")
+	}
+	if got, want := batch.HeaderGroups[0].Labels, []string{"//headers:base", "//headers:debug"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("batch header labels = %v, want %v", got, want)
+	}
+
+	t.Run("callback error", func(t *testing.T) {
+		_, err := tree.CompactMetadataBatchWithOptions(configs[:1], opts, func(*ResolvedConfig) (*KbuildFile, string, error) {
+			return nil, "", fmt.Errorf("sentinel")
+		})
+		if err == nil || !strings.Contains(err.Error(), `resolve Kbuild for config "debug": sentinel`) {
+			t.Fatalf("CompactMetadataBatchWithOptions() error = %v", err)
+		}
+	})
+	t.Run("nil Kbuild", func(t *testing.T) {
+		_, err := tree.CompactMetadataBatchWithOptions(configs[:1], opts, func(*ResolvedConfig) (*KbuildFile, string, error) {
+			return nil, "", nil
+		})
+		if err == nil || !strings.Contains(err.Error(), `resolve Kbuild for config "debug": nil Kbuild`) {
+			t.Fatalf("CompactMetadataBatchWithOptions() error = %v", err)
+		}
+	})
+}
+
 func TestCompactV013ContentIDsTrackOnlyTransitiveInputs(t *testing.T) {
 	tree := mustParseCompactFixture(t)
 	kb, err := ParseKbuild(strings.NewReader("obj-y += init.o\n"), "Kbuild")
@@ -1560,6 +1656,53 @@ func TestObjectVariantContentIDUsesFullChildIDs(t *testing.T) {
 	rightID := objectVariantContentID("composite.o", "y", "", nil, nil, "", "", nil, nil, []string{right}, "abi-v1")
 	if leftID == rightID {
 		t.Fatalf("full child content IDs with a shared presentation prefix produced the same parent ID %q", leftID)
+	}
+}
+
+func TestObjectVariantContentIDPreservesCanonicalFraming(t *testing.T) {
+	values := []string{
+		"object=drivers/example.o",
+		"mode=m",
+		"modname=example",
+		"compile_environment=environment-id",
+		"abi=abi-v1",
+		"source=drivers/example.c",
+		"flag=-Wall",
+		"flag=-DVALUE=1",
+		"remove_flag=-Werror",
+		"source_input=drivers/example.c\x00source-digest",
+		"source_input=include/example.h\x00header-digest",
+		"dep_content_id=dependency-id",
+		"member_content_id=member-id",
+	}
+	var canonical strings.Builder
+	canonical.WriteString(compactObjectContentDomain)
+	canonical.WriteByte(0)
+	for _, value := range values {
+		canonical.WriteString(value)
+		canonical.WriteByte(0)
+	}
+	sum := sha256.Sum256([]byte(canonical.String()))
+	want := hex.EncodeToString(sum[:])
+
+	got := objectVariantContentID(
+		"drivers/example.o",
+		"m",
+		"example",
+		[]string{"-Wall", "-DVALUE=1"},
+		[]string{"-Werror"},
+		"environment-id",
+		"drivers/example.c",
+		[]CompactSourceInput{
+			{Path: "drivers/example.c", Digest: "source-digest"},
+			{Path: "include/example.h", Digest: "header-digest"},
+		},
+		[]string{"dependency-id"},
+		[]string{"member-id"},
+		"abi-v1",
+	)
+	if got != want {
+		t.Fatalf("objectVariantContentID() = %q, want canonical hash %q", got, want)
 	}
 }
 

--- a/internal/kconfig/config_footprint.go
+++ b/internal/kconfig/config_footprint.go
@@ -23,12 +23,19 @@ type configSourceScanner struct {
 	includeRoots []string
 	predefined   map[string]bool
 	exact        bool
+	sourceCache  *compactSourceCache
 
 	files       map[string]scannedSourceFile
 	fileErrors  map[string]error
 	closure     map[string]sourceClosure
 	closureErrs map[string]error
 	configIDs   map[*ResolvedConfig]string
+}
+
+type compactSourceCache struct {
+	exactFiles  map[string]exactSourceFile
+	exactErrors map[string]error
+	treePaths   map[string]sourceTreePathResolution
 }
 
 type sourceClosure struct {
@@ -41,6 +48,17 @@ type scannedSourceFile struct {
 	refs     []string
 	includes []sourceIncludeDirective
 	digest   string
+}
+
+type exactSourceFile struct {
+	lines        []sourceLogicalLine
+	digest       string
+	preprocessed bool
+}
+
+type sourceTreePathResolution struct {
+	abs    string
+	exists bool
 }
 
 type sourceLogicalLine struct {
@@ -98,6 +116,18 @@ func (s sourceIncludeSearch) roots(kind sourceIncludeKind) []string {
 }
 
 func newConfigSourceScanner(opts CompactMetadataOptions) *configSourceScanner {
+	return newConfigSourceScannerWithCache(opts, newCompactSourceCache())
+}
+
+func newCompactSourceCache() *compactSourceCache {
+	return &compactSourceCache{
+		exactFiles:  map[string]exactSourceFile{},
+		exactErrors: map[string]error{},
+		treePaths:   map[string]sourceTreePathResolution{},
+	}
+}
+
+func newConfigSourceScannerWithCache(opts CompactMetadataOptions, sourceCache *compactSourceCache) *configSourceScanner {
 	roots := []string{}
 	if opts.Srcarch != "" {
 		roots = append(roots,
@@ -115,6 +145,7 @@ func newConfigSourceScanner(opts CompactMetadataOptions) *configSourceScanner {
 		includeRoots: roots,
 		predefined:   sourcePredefinedSymbols(opts.Srcarch),
 		exact:        opts.Schema.isV013(),
+		sourceCache:  sourceCache,
 		files:        map[string]scannedSourceFile{},
 		fileErrors:   map[string]error{},
 		closure:      map[string]sourceClosure{},
@@ -233,6 +264,13 @@ func (s *configSourceScanner) inputForTreePath(path string) (CompactSourceInput,
 	abs, ok := s.absForTreePath(cleaned)
 	if !ok {
 		return CompactSourceInput{}, fmt.Errorf("source-tree input %q does not exist", cleaned)
+	}
+	if s.exact {
+		digest, err := s.loadExactSourceDigest(abs)
+		if err != nil {
+			return CompactSourceInput{}, fmt.Errorf("%s: %w", cleaned, err)
+		}
+		return CompactSourceInput{Path: cleaned, Digest: digest}, nil
 	}
 	data, err := os.ReadFile(abs)
 	if err != nil {
@@ -593,6 +631,7 @@ func (s *configSourceScanner) scanFile(
 		cacheKey += "\x00" + s.configID(config)
 	}
 	if s.exact {
+		cacheKey += "\x00tree-path=" + treePath
 		cacheKey += "\x00assembly=" + strconv.FormatBool(assembly)
 		cacheKey += "\x00profile=" + string(profile)
 		cacheKey += "\x00include-search=" + search.cacheKey()
@@ -600,17 +639,30 @@ func (s *configSourceScanner) scanFile(
 	if cached, ok := s.files[cacheKey]; ok {
 		return cached, s.fileErrors[cacheKey]
 	}
-	data, err := os.ReadFile(abs)
-	if err != nil {
-		s.fileErrors[cacheKey] = err
-		return scannedSourceFile{}, err
-	}
-	text := string(data)
-	lines := rawSourceLines(text)
+	var (
+		digest string
+		lines  []sourceLogicalLine
+		text   string
+	)
 	if s.exact {
-		lines, text = preprocessExactSource(text)
+		file, err := s.loadExactSourceFile(abs)
+		if err != nil {
+			s.fileErrors[cacheKey] = err
+			return scannedSourceFile{}, err
+		}
+		digest = file.digest
+		lines = file.lines
+	} else {
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			s.fileErrors[cacheKey] = err
+			return scannedSourceFile{}, err
+		}
+		text = string(data)
+		lines = rawSourceLines(text)
+		digest = fileContentDigest(data)
 	}
-	scanned := scannedSourceFile{digest: fileContentDigest(data)}
+	scanned := scannedSourceFile{digest: digest}
 	refset := map[string]bool{}
 	if !s.exact {
 		for _, ref := range configRefs(text) {
@@ -746,6 +798,46 @@ func (s *configSourceScanner) scanFile(
 	scanned.refs = sortedStringSet(refset)
 	s.files[cacheKey] = scanned
 	return scanned, nil
+}
+
+func (s *configSourceScanner) loadExactSourceFile(abs string) (exactSourceFile, error) {
+	if cached, ok := s.sourceCache.exactFiles[abs]; ok && cached.preprocessed {
+		return cached, s.sourceCache.exactErrors[abs]
+	}
+	if err, ok := s.sourceCache.exactErrors[abs]; ok {
+		return exactSourceFile{}, err
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		s.sourceCache.exactErrors[abs] = err
+		return exactSourceFile{}, err
+	}
+	lines, _ := preprocessExactSource(string(data))
+	file := exactSourceFile{
+		lines:        lines,
+		digest:       fileContentDigest(data),
+		preprocessed: true,
+	}
+	s.sourceCache.exactFiles[abs] = file
+	return file, nil
+}
+
+func (s *configSourceScanner) loadExactSourceDigest(abs string) (string, error) {
+	if cached, ok := s.sourceCache.exactFiles[abs]; ok && cached.digest != "" {
+		return cached.digest, s.sourceCache.exactErrors[abs]
+	}
+	if err, ok := s.sourceCache.exactErrors[abs]; ok {
+		return "", err
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		s.sourceCache.exactErrors[abs] = err
+		return "", err
+	}
+	file := s.sourceCache.exactFiles[abs]
+	file.digest = fileContentDigest(data)
+	s.sourceCache.exactFiles[abs] = file
+	return file.digest, nil
 }
 
 func (s *configSourceScanner) configID(config *ResolvedConfig) string {
@@ -1430,16 +1522,23 @@ func (s *configSourceScanner) absForTreePath(path string) (string, bool) {
 	if !ok {
 		return "", false
 	}
+	if cached, ok := s.sourceCache.treePaths[path]; ok {
+		return cached.abs, cached.exists
+	}
+	resolved := sourceTreePathResolution{}
 	if s.sourceRoot != "" {
 		abs := filepath.Join(s.sourceRoot, filepath.FromSlash(path))
 		if fileExists(abs) {
-			return abs, true
+			resolved = sourceTreePathResolution{abs: abs, exists: true}
+			s.sourceCache.treePaths[path] = resolved
+			return resolved.abs, resolved.exists
 		}
 	}
 	if mapped, ok := mappedSourceRootPath(path, s.sourceRoots); ok && fileExists(mapped) {
-		return mapped, true
+		resolved = sourceTreePathResolution{abs: mapped, exists: true}
 	}
-	return "", false
+	s.sourceCache.treePaths[path] = resolved
+	return resolved.abs, resolved.exists
 }
 
 func cleanSourceTreePath(path string) (string, bool) {

--- a/internal/kconfig/config_footprint_test.go
+++ b/internal/kconfig/config_footprint_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -256,6 +257,125 @@ func TestConfigSourceScannerV013ConfigGatesNonliteralInclude(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("closureForSourceConfig(on) error = %q, want substring %q", err, want)
 		}
+	}
+}
+
+func TestConfigSourceScannerV013CachesPreprocessingAcrossConfigs(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/config-gated.c", `#ifdef CONFIG_CUSTOM
+#include "enabled.h"
+#else
+#include "disabled.h"
+#endif
+`)
+	mustWriteSource(t, root, "drivers/enabled.h", "#define ENABLED 1\n")
+	mustWriteSource(t, root, "drivers/disabled.h", "#define DISABLED 1\n")
+
+	opts := CompactMetadataOptions{
+		Schema:     CompactSchemaV013,
+		SourceRoot: root,
+	}
+	sourceCache := newCompactSourceCache()
+	contextScans := 0
+	scans := 0
+	for _, test := range []struct {
+		name   string
+		state  string
+		header string
+	}{
+		{name: "off", state: "n", header: "drivers/disabled.h"},
+		{name: "on", state: "y", header: "drivers/enabled.h"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scanner := newConfigSourceScannerWithCache(opts, sourceCache)
+			config := &ResolvedConfig{
+				Effective: map[string]string{"CONFIG_CUSTOM": test.state},
+				Written:   map[string]bool{"CONFIG_CUSTOM": true},
+			}
+			closure, err := scanner.closureForSourceConfig("drivers/config-gated.c", nil, config)
+			if err != nil {
+				t.Fatalf("closureForSourceConfig() failed: %v", err)
+			}
+			var paths []string
+			for _, input := range closure.sourceInputs {
+				paths = append(paths, input.Path)
+			}
+			want := []string{"drivers/config-gated.c", test.header}
+			sort.Strings(want)
+			if !reflect.DeepEqual(paths, want) {
+				t.Fatalf("source inputs = %v, want %v", paths, want)
+			}
+			contextScans += len(scanner.files)
+			scans++
+			if scans == 1 {
+				mustWriteSource(t, root, "drivers/config-gated.c", "#include \"replacement.h\"\n")
+				mustWriteSource(t, root, "drivers/replacement.h", "#define REPLACEMENT 1\n")
+			}
+		})
+	}
+
+	if got, want := contextScans, 4; got != want {
+		t.Fatalf("context-specific scan cache entries = %d, want %d", got, want)
+	}
+	if got, want := len(sourceCache.exactFiles), 3; got != want {
+		t.Fatalf("preprocessed file cache size = %d, want %d", got, want)
+	}
+}
+
+func TestConfigSourceScannerCachesMissingTreePaths(t *testing.T) {
+	scanner := newConfigSourceScanner(CompactMetadataOptions{
+		Schema:     CompactSchemaV013,
+		SourceRoot: t.TempDir(),
+	})
+	for range 2 {
+		if path, ok := scanner.absForTreePath("include/missing.h"); ok || path != "" {
+			t.Fatalf("absForTreePath(missing) = (%q, %v), want (\"\", false)", path, ok)
+		}
+	}
+	if got, want := len(scanner.sourceCache.treePaths), 1; got != want {
+		t.Fatalf("tree path cache size = %d, want %d", got, want)
+	}
+}
+
+func TestConfigSourceScannerV013SeparatesVirtualTreePaths(t *testing.T) {
+	root := t.TempDir()
+	mapped := t.TempDir()
+	mustWriteSource(t, mapped, "alias.h", `#if __has_include("relative.h")
+#include "relative.h"
+#endif
+`)
+	mustWriteSource(t, root, "one/relative.h", "#define RELATIVE 1\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{
+		Schema:     CompactSchemaV013,
+		SourceRoot: root,
+		SourceRoots: map[string]string{
+			"one": mapped,
+			"two": mapped,
+		},
+	})
+	for _, test := range []struct {
+		source string
+		want   []string
+	}{
+		{source: "one/alias.h", want: []string{"one/alias.h", "one/relative.h"}},
+		{source: "two/alias.h", want: []string{"two/alias.h"}},
+	} {
+		closure, err := scanner.exactClosureForSource(test.source, nil)
+		if err != nil {
+			t.Fatalf("exactClosureForSource(%q) failed: %v", test.source, err)
+		}
+		var paths []string
+		for _, input := range closure.sourceInputs {
+			paths = append(paths, input.Path)
+		}
+		if !reflect.DeepEqual(paths, test.want) {
+			t.Fatalf("exactClosureForSource(%q) inputs = %v, want %v", test.source, paths, test.want)
+		}
+	}
+
+	if got, want := len(scanner.sourceCache.exactFiles), 2; got != want {
+		t.Fatalf("shared physical file cache size = %d, want %d", got, want)
 	}
 }
 

--- a/internal/kconfig/kbuild.go
+++ b/internal/kconfig/kbuild.go
@@ -162,15 +162,30 @@ func parseKbuildFile(path string, vars map[string]string) (*KbuildFile, error) {
 }
 
 func ParseKbuildFileTree(path string, opts KbuildOptions) (*KbuildFile, error) {
+	return parseKbuildFileTree(path, opts, nil)
+}
+
+func parseKbuildFileTree(path string, opts KbuildOptions, variableOverrides map[string]string) (*KbuildFile, error) {
 	if opts.MaxIncludeDepth == 0 {
 		opts.MaxIncludeDepth = 64
 	}
-	treeParser := &kbuildTreeParser{
-		opts:    opts,
-		seen:    map[string]bool{},
-		parsing: map[string]bool{},
+	if opts.RootDir != "" {
+		if _, overridden := variableOverrides["srctree"]; !overridden {
+			if _, set := opts.Variables["srctree"]; !set {
+				if variableOverrides == nil {
+					variableOverrides = map[string]string{}
+				}
+				variableOverrides["srctree"] = opts.RootDir
+			}
+		}
 	}
-	parser := newKbuildParser(treeParser.variables(), "")
+	treeParser := &kbuildTreeParser{
+		opts:              opts,
+		variableOverrides: variableOverrides,
+		seen:              map[string]bool{},
+		parsing:           map[string]bool{},
+	}
+	parser := newKbuildParserWithOverrides(opts.Variables, variableOverrides, "")
 	parser.includeFunc = func(includes []KbuildInclude) error {
 		return treeParser.parseIncludes(parser, includes)
 	}
@@ -286,9 +301,16 @@ func parseKbuild(r io.Reader, filename string, vars map[string]string, baseDir s
 
 func (p *kbuildParser) finalizeObjectSettings() error {
 	names := make([]string, 0, len(p.vars))
-	for name := range p.vars {
-		names = append(names, name)
-	}
+	p.forEachVariableName(func(name string) {
+		if strings.HasPrefix(name, "CONFIG_") {
+			return
+		}
+		_, _, isObjectSetting := kbuildObjectSettingName(name)
+		_, language, isObjectFlags := perObjectFlagTarget(name)
+		if isObjectSetting || (isObjectFlags && language == "c") {
+			names = append(names, name)
+		}
+	})
 	sort.Strings(names)
 	for _, variable := range names {
 		name, object, ok := kbuildObjectSettingName(variable)
@@ -375,15 +397,17 @@ func (p *kbuildParser) parseReader(r io.Reader, filename string) error {
 func (p *kbuildParser) appendMakefileList(filename string) {
 	filename = filepath.ToSlash(filename)
 	current := ""
-	if variable, ok := p.vars["MAKEFILE_LIST"]; ok {
+	if variable, ok := p.lookupVariable("MAKEFILE_LIST"); ok {
 		current = variable.value
 	}
-	p.vars["MAKEFILE_LIST"] = kbuildVariable{value: appendMakeValue(current, filename)}
+	p.setVariable("MAKEFILE_LIST", kbuildVariable{value: appendMakeValue(current, filename)})
 }
 
 type kbuildParser struct {
 	kb           *KbuildFile
+	initialVars  map[string]string
 	vars         map[string]kbuildVariable
+	undefined    map[string]bool
 	locals       []map[string]string
 	expanding    map[string]bool
 	conds        []kbuildConditionalFrame
@@ -419,16 +443,58 @@ type kbuildConditionalFrame struct {
 }
 
 func newKbuildParser(vars map[string]string, baseDir string) *kbuildParser {
-	copied := map[string]kbuildVariable{}
-	for key, value := range vars {
-		copied[key] = kbuildVariable{value: value}
+	return newKbuildParserWithOverrides(vars, nil, baseDir)
+}
+
+func newKbuildParserWithOverrides(vars, overrides map[string]string, baseDir string) *kbuildParser {
+	local := make(map[string]kbuildVariable, len(overrides))
+	for key, value := range overrides {
+		local[key] = kbuildVariable{value: value}
 	}
 	return &kbuildParser{
 		kb:          &KbuildFile{},
-		vars:        copied,
+		initialVars: vars,
+		vars:        local,
 		expanding:   map[string]bool{},
 		baseDir:     baseDir,
 		currentRule: -1,
+	}
+}
+
+func (p *kbuildParser) lookupVariable(name string) (kbuildVariable, bool) {
+	if p.undefined[name] {
+		return kbuildVariable{}, false
+	}
+	if variable, ok := p.vars[name]; ok {
+		return variable, true
+	}
+	value, ok := p.initialVars[name]
+	return kbuildVariable{value: value}, ok
+}
+
+func (p *kbuildParser) setVariable(name string, variable kbuildVariable) {
+	delete(p.undefined, name)
+	p.vars[name] = variable
+}
+
+func (p *kbuildParser) undefineVariable(name string) {
+	delete(p.vars, name)
+	if p.undefined == nil {
+		p.undefined = map[string]bool{}
+	}
+	p.undefined[name] = true
+}
+
+func (p *kbuildParser) forEachVariableName(visit func(string)) {
+	for name := range p.initialVars {
+		if !p.undefined[name] {
+			visit(name)
+		}
+	}
+	for name := range p.vars {
+		if _, inherited := p.initialVars[name]; !inherited {
+			visit(name)
+		}
 	}
 }
 
@@ -739,7 +805,7 @@ func (p *kbuildParser) parseVariableDirective(line string) (bool, error) {
 			return true, err
 		}
 		for _, name := range names {
-			delete(p.vars, name)
+			p.undefineVariable(name)
 		}
 		return true, nil
 	}
@@ -755,8 +821,8 @@ func (p *kbuildParser) parseVariableDirective(line string) (bool, error) {
 			return true, err
 		}
 		for _, name := range names {
-			if _, ok := p.vars[name]; !ok {
-				p.vars[name] = kbuildVariable{}
+			if _, ok := p.lookupVariable(name); !ok {
+				p.setVariable(name, kbuildVariable{})
 			}
 		}
 		return true, nil
@@ -1139,25 +1205,25 @@ func (p *kbuildParser) expandPrerequisites(value string) ([]string, []string, er
 func (p *kbuildParser) assign(lhs, op, rhs, expandedRHS string) {
 	switch op {
 	case "+=":
-		current, ok := p.vars[lhs]
+		current, ok := p.lookupVariable(lhs)
 		switch {
 		case !ok:
-			p.vars[lhs] = kbuildVariable{value: rhs, recursive: true}
+			p.setVariable(lhs, kbuildVariable{value: rhs, recursive: true})
 		case current.recursive:
 			current.value = appendMakeValue(current.value, rhs)
-			p.vars[lhs] = current
+			p.setVariable(lhs, current)
 		default:
 			current.value = appendMakeValue(current.value, expandedRHS)
-			p.vars[lhs] = current
+			p.setVariable(lhs, current)
 		}
 	case "?=":
-		if _, ok := p.vars[lhs]; !ok {
-			p.vars[lhs] = kbuildVariable{value: rhs, recursive: true}
+		if _, ok := p.lookupVariable(lhs); !ok {
+			p.setVariable(lhs, kbuildVariable{value: rhs, recursive: true})
 		}
 	case "=":
-		p.vars[lhs] = kbuildVariable{value: rhs, recursive: true}
+		p.setVariable(lhs, kbuildVariable{value: rhs, recursive: true})
 	default:
-		p.vars[lhs] = kbuildVariable{value: expandedRHS}
+		p.setVariable(lhs, kbuildVariable{value: expandedRHS})
 	}
 }
 
@@ -1399,7 +1465,7 @@ func (p *kbuildParser) expandVariable(name, original string, depth int) (string,
 			return value, true, nil
 		}
 	}
-	variable, ok := p.vars[name]
+	variable, ok := p.lookupVariable(name)
 	if !ok {
 		return "", false, nil
 	}
@@ -1425,7 +1491,7 @@ func (p *kbuildParser) lookupRawVar(name string) (string, bool) {
 			return value, true
 		}
 	}
-	variable, ok := p.vars[name]
+	variable, ok := p.lookupVariable(name)
 	if !ok {
 		return "", false
 	}
@@ -1624,7 +1690,7 @@ func (p *kbuildParser) evalOrigin(args []string, original string, depth int) (st
 			return "automatic", nil
 		}
 	}
-	if _, ok := p.vars[name]; ok {
+	if _, ok := p.lookupVariable(name); ok {
 		return "file", nil
 	}
 	return "undefined", nil
@@ -1640,7 +1706,7 @@ func (p *kbuildParser) evalFlavor(args []string, original string, depth int) (st
 			return "simple", nil
 		}
 	}
-	variable, ok := p.vars[name]
+	variable, ok := p.lookupVariable(name)
 	if !ok {
 		return "undefined", nil
 	}
@@ -1731,9 +1797,10 @@ func (p *kbuildParser) evalOr(args []string, original string, depth int) (string
 }
 
 type kbuildTreeParser struct {
-	opts    KbuildOptions
-	seen    map[string]bool
-	parsing map[string]bool
+	opts              KbuildOptions
+	variableOverrides map[string]string
+	seen              map[string]bool
+	parsing           map[string]bool
 }
 
 func (p *kbuildTreeParser) parseInto(parser *kbuildParser, path string, depth int) error {
@@ -1834,25 +1901,21 @@ func (p *kbuildTreeParser) resolveInclude(path, baseDir string) (string, bool) {
 }
 
 func (p *kbuildTreeParser) expand(value string) string {
-	vars := p.variables()
-	for key, val := range vars {
+	if !containsMakeReference(value) {
+		return value
+	}
+	for key, val := range p.variableOverrides {
+		value = strings.ReplaceAll(value, "$("+key+")", val)
+		value = strings.ReplaceAll(value, "${"+key+"}", val)
+	}
+	for key, val := range p.opts.Variables {
+		if _, overridden := p.variableOverrides[key]; overridden {
+			continue
+		}
 		value = strings.ReplaceAll(value, "$("+key+")", val)
 		value = strings.ReplaceAll(value, "${"+key+"}", val)
 	}
 	return value
-}
-
-func (p *kbuildTreeParser) variables() map[string]string {
-	vars := map[string]string{}
-	for key, val := range p.opts.Variables {
-		vars[key] = val
-	}
-	if p.opts.RootDir != "" {
-		if _, ok := vars["srctree"]; !ok {
-			vars["srctree"] = p.opts.RootDir
-		}
-	}
-	return vars
 }
 
 func (kb *KbuildFile) merge(other *KbuildFile) {
@@ -1887,12 +1950,12 @@ func (p *kbuildDirectoryTreeParser) parsePath(path, objectDir string, gate Kbuil
 	}
 	local, ok := p.cache[abs]
 	if !ok {
-		vars := p.variables(objectDir)
-		parsed, err := ParseKbuildFileTree(abs, KbuildOptions{
+		variableOverrides := p.variableOverrides(objectDir)
+		parsed, err := parseKbuildFileTree(abs, KbuildOptions{
 			RootDir:         p.rootDir,
-			Variables:       vars,
+			Variables:       p.opts.Variables,
 			MaxIncludeDepth: p.opts.MaxIncludeDepth,
-		})
+		}, variableOverrides)
 		if err != nil {
 			return nil, err
 		}
@@ -2003,12 +2066,12 @@ func (p *kbuildDirectoryTreeParser) parseRootMakefile(path string) (*KbuildFile,
 	if ok {
 		return local, nil
 	}
-	vars := p.variables("")
-	parsed, err := ParseKbuildFileTree(abs, KbuildOptions{
+	variableOverrides := p.variableOverrides("")
+	parsed, err := parseKbuildFileTree(abs, KbuildOptions{
 		RootDir:         p.rootDir,
-		Variables:       vars,
+		Variables:       p.opts.Variables,
 		MaxIncludeDepth: p.opts.MaxIncludeDepth,
-	})
+	}, variableOverrides)
 	if err != nil {
 		return nil, err
 	}
@@ -2016,17 +2079,14 @@ func (p *kbuildDirectoryTreeParser) parseRootMakefile(path string) (*KbuildFile,
 	return parsed, nil
 }
 
-func (p *kbuildDirectoryTreeParser) variables(objectDir string) map[string]string {
-	vars := map[string]string{}
-	for key, value := range p.opts.Variables {
-		vars[key] = value
-	}
+func (p *kbuildDirectoryTreeParser) variableOverrides(objectDir string) map[string]string {
+	vars := make(map[string]string, 4)
 	vars["src"] = filepath.ToSlash(filepath.Join(p.rootDir, objectDir))
 	vars["obj"] = objectDir
-	if _, ok := vars["objtree"]; !ok {
+	if _, ok := p.opts.Variables["objtree"]; !ok {
 		vars["objtree"] = p.rootDir
 	}
-	if _, ok := vars["srctree"]; !ok {
+	if _, ok := p.opts.Variables["srctree"]; !ok {
 		vars["srctree"] = p.rootDir
 	}
 	return vars

--- a/internal/kconfig/kbuild_test.go
+++ b/internal/kconfig/kbuild_test.go
@@ -707,6 +707,68 @@ endif
 	}
 }
 
+func TestParseKbuildInitialVariablesUseMutableOverlay(t *testing.T) {
+	initial := map[string]string{
+		"objects":                    "initial.o",
+		"UBSAN_SANITIZE_inherited.o": "n",
+	}
+	kb, err := parseKbuild(strings.NewReader(`ifeq ("$(flavor objects)","simple")
+obj-y += initial-is-simple.o
+endif
+obj-y += $(objects)
+objects += appended.o
+obj-y += $(objects)
+objects ?= ignored.o
+undefine objects
+ifeq ("$(origin objects)","undefined")
+obj-y += initial-was-undefined.o
+endif
+objects ?= reset.o
+obj-y += $(objects)
+`), "Kbuild", initial, "")
+	if err != nil {
+		t.Fatalf("parseKbuild() failed: %v", err)
+	}
+
+	gotObjects := kbuildObjectSummaries(kb.Objects)
+	wantObjects := []kbuildObjectSummary{
+		{object: "initial-is-simple.o", kind: "const", state: "y", line: 2},
+		{object: "initial.o", kind: "const", state: "y", line: 4},
+		{object: "initial.o", kind: "const", state: "y", line: 6},
+		{object: "appended.o", kind: "const", state: "y", line: 6},
+		{object: "initial-was-undefined.o", kind: "const", state: "y", line: 10},
+		{object: "reset.o", kind: "const", state: "y", line: 13},
+	}
+	if !reflect.DeepEqual(gotObjects, wantObjects) {
+		t.Fatalf("objects mismatch\nwant: %#v\n got: %#v", wantObjects, gotObjects)
+	}
+
+	wantSettings := []kbuildObjectSetting{{
+		Name:   "UBSAN_SANITIZE",
+		Object: "inherited.o",
+		Value:  "n",
+	}}
+	if !reflect.DeepEqual(kb.objectSettings, wantSettings) {
+		t.Fatalf("object settings mismatch\nwant: %#v\n got: %#v", wantSettings, kb.objectSettings)
+	}
+	wantInitial := map[string]string{
+		"objects":                    "initial.o",
+		"UBSAN_SANITIZE_inherited.o": "n",
+	}
+	if !reflect.DeepEqual(initial, wantInitial) {
+		t.Fatalf("initial variables mutated\nwant: %#v\n got: %#v", wantInitial, initial)
+	}
+
+	second, err := parseKbuild(strings.NewReader("obj-y += $(objects)\n"), "second/Kbuild", initial, "")
+	if err != nil {
+		t.Fatalf("parseKbuild(second) failed: %v", err)
+	}
+	wantSecond := []kbuildObjectSummary{{object: "initial.o", kind: "const", state: "y", line: 1}}
+	if got := kbuildObjectSummaries(second.Objects); !reflect.DeepEqual(got, wantSecond) {
+		t.Fatalf("second parse objects mismatch\nwant: %#v\n got: %#v", wantSecond, got)
+	}
+}
+
 func TestParseKbuildExpandsMakeVariableIntrospection(t *testing.T) {
 	kb, err := ParseKbuild(strings.NewReader(`recursive = raw$(suffix)
 simple := simple.o


### PR DESCRIPTION
## Summary

Reduce compact v0.0.13 repository-generation cost when one invocation emits several kernel configurations.

The generator was repeating and retaining three expensive forms of work:

- each Kbuild directory parser copied the complete resolved `CONFIG_*` map before applying a handful of local variables;
- each config-specific metadata pass reread and preprocessed the same immutable source files;
- object content IDs assembled large temporary string slices before hashing them.

This change uses an immutable Kbuild variable base with a small mutable overlay, processes per-config Kbuild graphs through one invocation-bounded batch API, shares only exact source preprocessing/path state between configs, and streams content-ID fields directly into SHA-256. Per-config semantic scan maps remain isolated so config-dependent preprocessing cannot leak across variants. The batch boundary also removes the CLI's duplicate Kconfig resolution.

Optional CPU, heap, and cumulative-allocation profile flags are included so repository-generation regressions can be diagnosed directly. Profile cleanup runs on success and error exits.

## Measured impact

Production-shaped Linux 6.18.39 generation for x86_64 base, BTF, debug, and LZ4 configs, using the same command and inputs:

- wall time: **162.82s -> 23.12s** (**85.8% lower, 7.0x faster**)
- peak RSS: **4,411,088 KiB -> 1,087,436 KiB** (**75.3% lower**)
- generated metadata: byte-for-byte identical (`cmp` and SHA-256)
- generated BUILD file: byte-for-byte identical (`cmp` and SHA-256)

These are single baseline/final samples from the local production fixture; the exact-output comparison is the correctness gate.

## Validation

- `go test -count=1 ./...`
- `CC=clang go test -race -count=1 ./internal/kconfig ./internal/cmd/kconfig_parse`
- `go vet ./...`
- `bazel test //internal/kconfig/... //internal/cmd/kconfig_parse:kconfig_parse_test //tests/compact/... //:buildifier_test`
- real Linux 6.18.39 four-config metadata and BUILD byte comparison
- error-path CPU/heap/alloc profile finalization