### PR TITLE
Repair analysis CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
             --bazelrc="${GITHUB_WORKSPACE}/.github/workflows/ci.bazelrc" \
             test "${targets[@]}" \
             "${path_mapping_args[@]}" \
-            --notrack_incremental_state \
-            --nokeep_state_after_build \
-            --discard_analysis_cache \
             --build_event_json_file="${BAZEL_BEP}" \
             --profile="${BAZEL_PROFILE}" \
             2>&1 | tee "${BAZEL_LOG}"

--- a/aya_e2e/patches/aya_linux_bzl_api.patch
+++ b/aya_e2e/patches/aya_linux_bzl_api.patch
@@ -30,7 +30,7 @@ index 00d93a2..e591333 100644
  
  # Each qemu-system toolchain is compatible with the corresponding
  # //bazel:bpf_target_arch value. bazel/vm.bzl transitions that value for each
-@@ -74,7 +75,18 @@
+@@ -74,7 +75,30 @@
  
  register_toolchains(
      "@copy_to_directory_toolchains//:all",
@@ -39,16 +39,28 @@ index 00d93a2..e591333 100644
 -    "@llvm//toolchain:all",
 +    "@llvm//toolchain:linux_aarch64_to_linux_aarch64",
 +    "@llvm//toolchain:linux_aarch64_to_linux_x86_64",
++    "@llvm//toolchain:linux_aarch64_to_none_bpfeb",
++    "@llvm//toolchain:linux_aarch64_to_none_bpfel",
 +    "@llvm//toolchain:linux_x86_64_to_linux_aarch64",
 +    "@llvm//toolchain:linux_x86_64_to_linux_x86_64",
++    "@llvm//toolchain:linux_x86_64_to_none_bpfeb",
++    "@llvm//toolchain:linux_x86_64_to_none_bpfel",
 +    "@llvm//toolchain:macos_aarch64_to_linux_aarch64",
 +    "@llvm//toolchain:macos_aarch64_to_linux_x86_64",
++    "@llvm//toolchain:macos_aarch64_to_none_bpfeb",
++    "@llvm//toolchain:macos_aarch64_to_none_bpfel",
 +    "@llvm//toolchain:macos_x86_64_to_linux_aarch64",
 +    "@llvm//toolchain:macos_x86_64_to_linux_x86_64",
++    "@llvm//toolchain:macos_x86_64_to_none_bpfeb",
++    "@llvm//toolchain:macos_x86_64_to_none_bpfel",
 +    "@llvm//toolchain:windows_aarch64_to_linux_aarch64",
 +    "@llvm//toolchain:windows_aarch64_to_linux_x86_64",
++    "@llvm//toolchain:windows_aarch64_to_none_bpfeb",
++    "@llvm//toolchain:windows_aarch64_to_none_bpfel",
 +    "@llvm//toolchain:windows_x86_64_to_linux_aarch64",
 +    "@llvm//toolchain:windows_x86_64_to_linux_x86_64",
++    "@llvm//toolchain:windows_x86_64_to_none_bpfeb",
++    "@llvm//toolchain:windows_x86_64_to_none_bpfel",
      "@qemu_system_toolchains//:all",
  )
 @@ -126,54 +126,34 @@ use_repo(crate, "crates")

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -374,6 +374,17 @@ build_test(
     ],
 )
 
+build_test(
+    name = "linux_source_root_package_build_test",
+    targets = [
+        "@e2e_linux_6_18_39//:tools/bpf/resolve_btfids/main.c",
+        "@e2e_linux_6_18_39//:tools/lib/subcmd/Build.linux-bzl",
+        "@e2e_linux_6_18_39//:tools/lib/subcmd/subcmd-config.c",
+        "@e2e_linux_6_18_39//:tools/objtool/arch/x86/decode.c",
+        "@e2e_linux_6_18_39//:tools/objtool/objtool.c",
+    ],
+)
+
 test_suite(
     name = "kernel_outputs_build_test",
     tests = [

--- a/internal/linux_source_repository.bzl
+++ b/internal/linux_source_repository.bzl
@@ -26,6 +26,60 @@ _KERNEL_RELEASES = {
     ),
 }
 
+# Case-insensitive filesystems treat Linux's tools/**/Build make fragments as
+# Bazel package markers. Relocate them on every host for identical repositories.
+_TOOLS_BUILD_FILE = "Build"
+_TOOLS_BUILD_FILE_RELOCATED = "Build.linux-bzl"
+_TOOLS_MAX_DEPTH = 64
+
+def _relocate_tools_build_files(rctx, tools):
+    relocated = 0
+    directories = [tools]
+    for _ in range(_TOOLS_MAX_DEPTH):
+        if not directories:
+            break
+        next_directories = []
+        for directory in directories:
+            for entry in directory.readdir(watch = "no"):
+                if entry.is_dir:
+                    next_directories.append(entry)
+                elif entry.basename == _TOOLS_BUILD_FILE:
+                    rctx.rename(
+                        entry,
+                        entry.dirname.get_child(_TOOLS_BUILD_FILE_RELOCATED),
+                    )
+                    relocated += 1
+        directories = next_directories
+    if directories:
+        fail("Linux tools directory exceeds the supported traversal depth")
+    return relocated
+
+def _normalize_tools_build_files(rctx):
+    tools = rctx.path("tools")
+    if not tools.exists:
+        return
+
+    relocated = _relocate_tools_build_files(rctx, tools)
+    if relocated == 0:
+        return
+
+    makefile = rctx.path("tools/build/Makefile.build")
+    if not makefile.exists:
+        fail("Linux tools contain Build files but no tools/build/Makefile.build")
+
+    build_file_assignment = "build-file := $(dir)/Build\n"
+    relocated_assignment = "build-file := $(dir)/%s\n" % _TOOLS_BUILD_FILE_RELOCATED
+    content = rctx.read(makefile)
+    if build_file_assignment not in content:
+        fail(
+            "Linux tools/build/Makefile.build does not contain the expected Build assignment",
+        )
+    rctx.file(
+        makefile,
+        content.replace(build_file_assignment, relocated_assignment),
+        executable = False,
+    )
+
 def _linux_source_repository_impl(rctx):
     catalog = _KERNEL_RELEASES.get(rctx.attr.version)
     has_urls = len(rctx.attr.urls) != 0
@@ -60,6 +114,7 @@ def _linux_source_repository_impl(rctx):
     )
     for patch in rctx.attr.patches:
         rctx.patch(patch, strip = rctx.attr.patch_strip)
+    _normalize_tools_build_files(rctx)
 
     makefile = rctx.path("Makefile")
     kconfig = rctx.path("Kconfig")


### PR DESCRIPTION
## Summary

- register the targeted LLVM BPF toolchains required by Aya's transitioned eBPF targets
- avoid Bazel 8.7's internal crash by retaining analysis state in the root test job
- relocate upstream Linux `tools/**/Build` make fragments to `Build.linux-bzl` and update the tools make driver, preventing accidental Bazel package boundaries on case-insensitive filesystems
- add an e2e build test for direct source labels across the affected tool directories

## Root causes

The selective Aya toolchain registration kept Linux kernel cross-toolchains but omitted BPF targets. The root job combined `--notrack_incremental_state`, `--nokeep_state_after_build`, and `--discard_analysis_cache`, which triggers Bazel 8.7's `ALREADY_DECLARED_CHILD_MISSING` internal inconsistency. On macOS and Windows, upstream files named `Build` are case-insensitively interpreted as Bazel BUILD files, truncating the root source package and invalidating 19 direct host-tool source labels.

## Validation

- `USE_BAZEL_VERSION=8.7.0 bazel ... test //...`: 109/109 tests pass
- Aya `ringbuf_btf_bpf` analysis with `--nobuild`: passes
- Bazel 8.7 and 9.1 `//:linux_source_root_package_build_test`: pass
- full builds of `_base_resolve_btfids_tool` and `_base_x86_objtool`: pass
- source repository inspection: all 79 `tools/**/Build` files relocated and `tools/build/Makefile.build` updated
- `bazel test //:buildifier_test`
- `git diff --check`

Stacked on #29.