### PR TITLE
kconfig: emit complete source input closures

### DIFF
--- a/KCONFIG_RELEASING.md
+++ b/KCONFIG_RELEASING.md
@@ -10,9 +10,9 @@ Generator releases are tagged as `kconfig-vX.Y.Z`.
 goldens must remain byte-compatible until the rules repository explicitly
 requests another schema.
 
-Schema `v0.0.12` is opt-in. It emits classified source-tree inputs, exact
-source-like include closures, module object roots, and fail-closed source
-actions. Rust-owned objects are excluded from the ordinary object graph.
+Schema `v0.0.12` is opt-in. It emits classified source-tree inputs, recursively
+resolved literal source include closures, module object roots, and fail-closed
+source actions. Rust-owned objects are excluded from the ordinary object graph.
 `-rust_profile_out` additionally emits a source-derived Rust profile and is
 valid only with `-compact_schema=v0.0.12`.
 
@@ -29,6 +29,21 @@ verify that dynamic rustc capabilities do not change the repository-generated
 structural snapshot. Compact object metadata preserves module roots and
 `OBJECT_FILES_NON_STANDARD` overrides, and can carry the source-built x86
 objtool label required for Kbuild-compatible post-processing.
+
+Generator `v0.0.15` keeps compact schema `v0.0.12` and extends each generated
+object with its recursively resolved private header closure. Global and
+selected-architecture headers remain classified source-tree inputs instead of
+being repeated on every object. A computed preprocessor include, unresolved
+forced source include, or unmodeled source include-search flag marks the
+closure incomplete so rules consumers retain their exhaustive full-tree
+fallback. Assembler `.incbin` dependencies also use that fallback. Source-root
+include directories, forced includes, comments, and preprocessor line splices
+are included in the scan. Rules consumers pass exact
+generated include spellings, with source backings for generated asm-generic
+wrappers. Other unresolved literals cannot name source files once the source
+search model is complete; generated and toolchain providers remain independent
+action inputs. Consumers assert generated-manifest completeness explicitly;
+other compact metadata producers retain the exhaustive fallback.
 
 ## Prepare
 
@@ -58,7 +73,7 @@ version stream.
 After the release-preparation change is merged, tag that merge commit:
 
 ```sh
-VERSION=v0.0.14 ./release_kconfig.sh
+VERSION=v0.0.15 ./release_kconfig.sh
 ```
 
 The tag workflow publishes archives for Linux, macOS, and Windows on amd64 and

--- a/internal/cmd/kconfig_parse/main.go
+++ b/internal/cmd/kconfig_parse/main.go
@@ -53,6 +53,44 @@ func (f *stringSliceFlag) Set(value string) error {
 	return nil
 }
 
+type generatedIncludeFlag map[string][]string
+
+func (f generatedIncludeFlag) String() string {
+	keys := make([]string, 0, len(f))
+	for key := range f {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var entries []string
+	for _, key := range keys {
+		if len(f[key]) == 0 {
+			entries = append(entries, key)
+			continue
+		}
+		for _, backing := range f[key] {
+			entries = append(entries, key+"="+backing)
+		}
+	}
+	return strings.Join(entries, ",")
+}
+
+func (f generatedIncludeFlag) Set(value string) error {
+	include, backing, hasBacking := strings.Cut(value, "=")
+	include = strings.TrimSpace(include)
+	backing = strings.TrimSpace(backing)
+	if include == "" || (hasBacking && backing == "") {
+		return fmt.Errorf("expected INCLUDE or INCLUDE=SOURCE")
+	}
+	if !hasBacking {
+		if _, ok := f[include]; !ok {
+			f[include] = nil
+		}
+		return nil
+	}
+	f[include] = append(f[include], backing)
+	return nil
+}
+
 type namedPath struct {
 	Name string
 	Path string
@@ -168,6 +206,8 @@ func main() {
 		vars                     = stringMapFlag{}
 		env                      = stringMapFlag{}
 		linuxProbeValues         = stringMapFlag{}
+		sourceGeneratedIncludes  = generatedIncludeFlag{}
+		sourceGeneratedComplete  = flag.Bool("source_generated_includes_complete", false, "Assert that -source_generated_include covers every generated header spelling available to compact compile actions")
 		visibility               = stringSliceFlag{}
 		kbuildTreeExcludes       = stringSliceFlag{}
 		compactConfigInputs      = namedPathFlag{}
@@ -191,6 +231,7 @@ func main() {
 	flag.Var(vars, "var", "Preprocessor variable in KEY=VALUE form. May be repeated")
 	flag.Var(env, "env", "Hermetic environment variable in KEY=VALUE form. May be repeated")
 	flag.Var(linuxProbeValues, "linux_probe_value", "Linux probe override in KEY=VALUE form. May be repeated with -linux_probe_model")
+	flag.Var(sourceGeneratedIncludes, "source_generated_include", "Generated include spelling, optionally mapped to its source backing as INCLUDE=SOURCE. May be repeated")
 	flag.Var(&visibility, "visibility", "Default visibility for the generated BUILD file. May be repeated. Defaults to //visibility:public")
 	flag.Var(&kbuildTreeExcludes, "kbuild_tree_exclude", "Source-root-relative subtree to skip during -kbuild_tree_root validation. May be repeated")
 	flag.Var(&compactConfigInputs, "config", "Named .config input in NAME=PATH form for compact metadata generation. May be repeated")
@@ -387,7 +428,7 @@ func main() {
 	}
 
 	if *compactMetadataOut != "" || *compactBuildfileOut != "" || *objectBuildfileOut != "" || *imageBuildfileOut != "" {
-		metadata, err := compactMetadata(tree, *root, *kbuildPath, compactConfigInputs, compactConfigOverlays, *resolvedFlagsDir, *configMode, *compactKbuildTree, vars, kbuildExtras, namedPathMap(sourceRootMaps), compactSchema)
+		metadata, err := compactMetadata(tree, *root, *kbuildPath, compactConfigInputs, compactConfigOverlays, *resolvedFlagsDir, *configMode, *compactKbuildTree, vars, kbuildExtras, namedPathMap(sourceRootMaps), sourceGeneratedIncludes, *sourceGeneratedComplete, compactSchema)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to generate compact metadata: %v\n", err)
 			os.Exit(1)
@@ -930,7 +971,7 @@ func validateResolvedFlagsName(name string) error {
 	return nil
 }
 
-func compactMetadata(tree *kconfig.Tree, rootPath string, kbuildPath string, configInputs, configOverlays []namedPath, resolvedFlagsDir string, configMode string, compactKbuildTree bool, vars map[string]string, kbuildExtras []namedPath, sourceRoots map[string]string, schema kconfig.CompactSchema) (*kconfig.CompactMetadata, error) {
+func compactMetadata(tree *kconfig.Tree, rootPath string, kbuildPath string, configInputs, configOverlays []namedPath, resolvedFlagsDir string, configMode string, compactKbuildTree bool, vars map[string]string, kbuildExtras []namedPath, sourceRoots map[string]string, sourceGeneratedIncludes map[string][]string, sourceGeneratedIncludesComplete bool, schema kconfig.CompactSchema) (*kconfig.CompactMetadata, error) {
 	if kbuildPath == "" {
 		return nil, fmt.Errorf("-kbuild is required")
 	}
@@ -996,12 +1037,14 @@ func compactMetadata(tree *kconfig.Tree, rootPath string, kbuildPath string, con
 		}
 	}
 	opts := kconfig.CompactMetadataOptions{
-		Schema:      schema,
-		ObjectDir:   objectDir,
-		SourceRoot:  sourceRoot,
-		SourceRoots: sourceRoots,
-		LibraryDirs: kbuildLibraryDirs(vars),
-		Srcarch:     vars["SRCARCH"],
+		Schema:                          schema,
+		ObjectDir:                       objectDir,
+		SourceRoot:                      sourceRoot,
+		SourceRoots:                     sourceRoots,
+		SourceGeneratedIncludes:         sourceGeneratedIncludes,
+		SourceGeneratedIncludesComplete: sourceGeneratedIncludesComplete,
+		LibraryDirs:                     kbuildLibraryDirs(vars),
+		Srcarch:                         vars["SRCARCH"],
 	}
 	rootDir := sourceRoot
 	if rootDir == "" {

--- a/internal/cmd/kconfig_parse/main_test.go
+++ b/internal/cmd/kconfig_parse/main_test.go
@@ -27,6 +27,28 @@ func TestApplyRustToolchainProbe(t *testing.T) {
 	}
 }
 
+func TestGeneratedIncludeFlag(t *testing.T) {
+	values := generatedIncludeFlag{}
+	for _, value := range []string{
+		"generated/autoconf.h",
+		"asm/rwonce.h=include/asm-generic/rwonce.h",
+		"asm/errno.h=include/uapi/asm-generic/errno.h",
+	} {
+		if err := values.Set(value); err != nil {
+			t.Fatalf("Set(%q) failed: %v", value, err)
+		}
+	}
+	if got := values["generated/autoconf.h"]; got != nil {
+		t.Fatalf("generated/autoconf.h backings = %v, want nil", got)
+	}
+	if got, want := strings.Join(values["asm/rwonce.h"], ","), "include/asm-generic/rwonce.h"; got != want {
+		t.Fatalf("asm/rwonce.h backings = %q, want %q", got, want)
+	}
+	if err := values.Set("missing="); err == nil {
+		t.Fatal("Set(missing=) succeeded")
+	}
+}
+
 func TestKbuildVariablesForConfigUsesWrittenConfigView(t *testing.T) {
 	vars := kbuildVariablesForConfig(
 		map[string]string{
@@ -156,6 +178,8 @@ func TestCompactMetadataRejectsUnmatchedOverlay(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		false,
 		kconfig.CompactSchemaV012,
 	)
 	if err == nil || !strings.Contains(err.Error(), `config overlay "other" has no matching -config`) {
@@ -179,6 +203,8 @@ func TestCompactMetadataRejectsDuplicateOverlay(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
+		false,
 		kconfig.CompactSchemaV012,
 	)
 	if err == nil || !strings.Contains(err.Error(), `duplicate config overlay name "base"`) {
@@ -201,6 +227,8 @@ func TestCompactMetadataRejectsUnsafeResolvedFlagsNames(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
+				false,
 				kconfig.CompactSchemaV012,
 			)
 			if err == nil || !strings.Contains(err.Error(), "must be a single path component") {

--- a/internal/compact_generator.bzl
+++ b/internal/compact_generator.bzl
@@ -104,6 +104,10 @@ def _linux_compact_outputs_impl(ctx):
         args.add("-source_tree_scripts_headers_label", label)
     for label in ctx.attr.source_tree_uapi_headers_labels:
         args.add("-source_tree_uapi_headers_label", label)
+    for include in ctx.attr.source_generated_includes:
+        args.add("-source_generated_include", include)
+    if ctx.attr.source_generated_includes_complete:
+        args.add("-source_generated_includes_complete")
     args.add("-linux_objects_load", ctx.attr.linux_objects_load)
     env = dict(ctx.attr.env)
     vars = dict(ctx.attr.vars)
@@ -260,6 +264,12 @@ _linux_compact_outputs = rule(
         ),
         "source_root_label": attr.string(
             doc = "Label for a file in the Linux source root emitted into source-backed compact object rules.",
+        ),
+        "source_generated_includes": attr.string_list(
+            doc = "Generated include spellings, optionally mapped to source backings as INCLUDE=SOURCE.",
+        ),
+        "source_generated_includes_complete": attr.bool(
+            doc = "Whether source_generated_includes covers every generated header available to compact compile actions.",
         ),
         "source_tree_all_files_labels": attr.string_list(
             doc = "Labels for explicit full source tree inputs emitted into source-backed compact object rules.",
@@ -519,6 +529,8 @@ def linux_compact_buildfiles(
         source_relacheck = "",
         source_config = "",
         source_root_label = "",
+        source_generated_includes = [],
+        source_generated_includes_complete = False,
         source_tree_all_files_labels = [],
         source_tree_arch_headers_labels = [],
         source_tree_dtb_sources_labels = [],
@@ -573,6 +585,8 @@ def linux_compact_buildfiles(
         source_asn1_compiler = source_asn1_compiler,
         source_relacheck = source_relacheck,
         source_config = source_config,
+        source_generated_includes = source_generated_includes,
+        source_generated_includes_complete = source_generated_includes_complete,
         source_root_label = source_root_label,
         source_tree_all_files_labels = source_tree_all_files_labels,
         source_tree_arch_headers_labels = source_tree_arch_headers_labels,

--- a/internal/kconfig/compact.go
+++ b/internal/kconfig/compact.go
@@ -54,22 +54,23 @@ type CompactConfig struct {
 }
 
 type CompactObjectVariant struct {
-	Target          string            `json:"target"`
-	Package         string            `json:"package,omitempty"`
-	Object          string            `json:"object"`
-	Source          string            `json:"source,omitempty"`
-	SourceIncludes  []string          `json:"source_includes,omitempty"`
-	Mode            string            `json:"mode"`
-	ModuleRoot      bool              `json:"module_root,omitempty"`
-	ModName         string            `json:"modname,omitempty"`
-	Flags           []string          `json:"flags,omitempty"`
-	RemoveFlags     []string          `json:"remove_flags,omitempty"`
-	ObjtoolArgs     []string          `json:"objtool_args,omitempty"`
-	ObjtoolDisabled bool              `json:"objtool_disabled,omitempty"`
-	ObjtoolForce    bool              `json:"objtool_force,omitempty"`
-	ConfigFragment  map[string]string `json:"config_fragment,omitempty"`
-	Deps            []string          `json:"deps,omitempty"`
-	Members         []string          `json:"members,omitempty"`
+	Target                 string            `json:"target"`
+	Package                string            `json:"package,omitempty"`
+	Object                 string            `json:"object"`
+	Source                 string            `json:"source,omitempty"`
+	SourceIncludes         []string          `json:"source_includes,omitempty"`
+	SourceIncludesComplete bool              `json:"source_includes_complete,omitempty"`
+	Mode                   string            `json:"mode"`
+	ModuleRoot             bool              `json:"module_root,omitempty"`
+	ModName                string            `json:"modname,omitempty"`
+	Flags                  []string          `json:"flags,omitempty"`
+	RemoveFlags            []string          `json:"remove_flags,omitempty"`
+	ObjtoolArgs            []string          `json:"objtool_args,omitempty"`
+	ObjtoolDisabled        bool              `json:"objtool_disabled,omitempty"`
+	ObjtoolForce           bool              `json:"objtool_force,omitempty"`
+	ConfigFragment         map[string]string `json:"config_fragment,omitempty"`
+	Deps                   []string          `json:"deps,omitempty"`
+	Members                []string          `json:"members,omitempty"`
 }
 
 type CompactObjectPackage struct {
@@ -126,11 +127,15 @@ func (opts CompactBuildFileOptions) hasSourceTreeLabels() bool {
 }
 
 type CompactMetadataOptions struct {
-	Schema      CompactSchema
-	ObjectDir   string
-	SourceRoot  string
-	SourceRoots map[string]string
-	LibraryDirs []string
+	Schema                  CompactSchema
+	ObjectDir               string
+	SourceRoot              string
+	SourceRoots             map[string]string
+	SourceGeneratedIncludes map[string][]string
+	// SourceGeneratedIncludesComplete asserts that SourceGeneratedIncludes
+	// covers every generated header spelling provided to compile actions.
+	SourceGeneratedIncludesComplete bool
+	LibraryDirs                     []string
 	// Srcarch selects architecture include roots while scanning source files for
 	// CONFIG_* dependencies.
 	Srcarch string
@@ -372,7 +377,7 @@ func cleanKbuildDir(dir string) string {
 }
 
 func (v CompactObjectVariant) equal(other CompactObjectVariant) bool {
-	if v.Target != other.Target || v.Package != other.Package || v.Object != other.Object || v.Source != other.Source || v.Mode != other.Mode || v.ModuleRoot != other.ModuleRoot || v.ModName != other.ModName || v.ObjtoolDisabled != other.ObjtoolDisabled || v.ObjtoolForce != other.ObjtoolForce || len(v.SourceIncludes) != len(other.SourceIncludes) || len(v.Flags) != len(other.Flags) || len(v.RemoveFlags) != len(other.RemoveFlags) || len(v.ObjtoolArgs) != len(other.ObjtoolArgs) || len(v.ConfigFragment) != len(other.ConfigFragment) || len(v.Deps) != len(other.Deps) || len(v.Members) != len(other.Members) {
+	if v.Target != other.Target || v.Package != other.Package || v.Object != other.Object || v.Source != other.Source || v.SourceIncludesComplete != other.SourceIncludesComplete || v.Mode != other.Mode || v.ModuleRoot != other.ModuleRoot || v.ModName != other.ModName || v.ObjtoolDisabled != other.ObjtoolDisabled || v.ObjtoolForce != other.ObjtoolForce || len(v.SourceIncludes) != len(other.SourceIncludes) || len(v.Flags) != len(other.Flags) || len(v.RemoveFlags) != len(other.RemoveFlags) || len(v.ObjtoolArgs) != len(other.ObjtoolArgs) || len(v.ConfigFragment) != len(other.ConfigFragment) || len(v.Deps) != len(other.Deps) || len(v.Members) != len(other.Members) {
 		return false
 	}
 	for i := range v.SourceIncludes {
@@ -1011,15 +1016,35 @@ func (memo compactVariantMemo) variantForStack(name string, config *ResolvedConf
 	}
 
 	var sourceRefs, sourceIncludes []string
+	sourceIncludesComplete := false
 	if opts.Schema.isV012() {
 		flags := normalizeSourceRootFlags(filterResolvedKbuildFlags(object.flags, source), opts.SourceRoot)
-		sourceRefs = scanner.refsForSource(source, includeDirsFromFlags(flags))
-		sourceIncludes = scanner.sourceIncludesForSource(source, includeDirsFromFlags(flags))
+		sourceSearchComplete := opts.SourceGeneratedIncludesComplete && sourceIncludeFlagsComplete(flags)
+		includeRoots := includeDirsFromFlags(flags, source)
+		closure := scanner.closureForSource(
+			source,
+			includeRoots,
+			forcedIncludesFromFlags(flags, source),
+			sourceSearchComplete,
+		)
+		sourceRefs = append([]string(nil), closure.refs...)
+		preincludes := scanner.closureForPreincludes(source, includeRoots, sourceSearchComplete)
+		sourceRefs = append(sourceRefs, preincludes.refs...)
+		sourceIncludes = append([]string(nil), closure.sourceIncludes...)
+		for _, include := range preincludes.sourceIncludes {
+			sourceIncludes = appendUnique(sourceIncludes, include)
+		}
+		sort.Strings(sourceIncludes)
+		sourceIncludesComplete = sourceSearchComplete && closure.sourceIncludesComplete && preincludes.sourceIncludesComplete
+		if objectUsesGeneratedCSource(name) {
+			sourceIncludesComplete = false
+		}
 		if isMultiSourceImageObject(name) {
 			sourceRefs = append(sourceRefs, scanner.refsForSourceDir(objectPackage(name))...)
+			sourceIncludesComplete = false
 		}
 	}
-	variant := object.variant(config, source, sourceIncludes, members, deps, opts.SourceRoot, sourceRefs, opts.Schema.isV012())
+	variant := object.variant(config, source, sourceIncludes, sourceIncludesComplete, members, deps, opts.SourceRoot, sourceRefs, opts.Schema.isV012())
 	memo[name] = variant
 	return variant, nil
 }
@@ -1030,33 +1055,182 @@ func isMultiSourceImageObject(object string) bool {
 		object == "arch/x86/purgatory/kexec-purgatory.o"
 }
 
+func objectUsesGeneratedCSource(object string) bool {
+	return strings.HasSuffix(object, ".asn1.o") ||
+		object == "arch/x86/kernel/cpu/capflags.o" ||
+		object == "drivers/tty/vt/consolemap_deftbl.o"
+}
+
 func objectNeedsFullConfig(object string) bool {
 	return object == "arch/x86/purgatory/kexec-purgatory.o"
 }
 
-func includeDirsFromFlags(flags []string) []string {
+func includeDirsFromFlags(flags []string, source string) []string {
 	var dirs []string
-	for i := 0; i < len(flags); i++ {
-		path := ""
-		if flags[i] == "-I" && i+1 < len(flags) {
-			path = flags[i+1]
-			i++
-		} else if rest, ok := strings.CutPrefix(flags[i], "-I"); ok {
-			path = rest
-		} else {
-			continue
-		}
-		path = strings.TrimSpace(path)
-		if path == "$(srctree)" {
-			dirs = append(dirs, "")
-		} else if rel, ok := strings.CutPrefix(path, "$(srctree)/"); ok {
-			dirs = append(dirs, rel)
+	for _, path := range flagOptionValues(flags, "-I", "-iquote", "-isystem", "-idirafter") {
+		for _, dir := range sourceTreeFlagPaths(path, source) {
+			dirs = appendUnique(dirs, dir)
 		}
 	}
 	return dirs
 }
 
-func (o resolvedKbuildObject) variant(config *ResolvedConfig, source string, sourceIncludes, members, deps []string, sourceRoot string, sourceRefs []string, v012 bool) CompactObjectVariant {
+func forcedIncludesFromFlags(flags []string, source string) []sourceForcedInclude {
+	var includes []sourceForcedInclude
+	for _, path := range flagOptionValues(flags, "-include", "-imacros") {
+		include := sourceForcedInclude{}
+		switch {
+		case path == "$(srctree)", path == "${srctree}":
+			include.path = ""
+			include.direct = true
+		case strings.HasPrefix(path, "$(srctree)/"):
+			include.path = strings.TrimPrefix(path, "$(srctree)/")
+			include.direct = true
+		case strings.HasPrefix(path, "${srctree}/"):
+			include.path = strings.TrimPrefix(path, "${srctree}/")
+			include.direct = true
+		case path == "$(src)", path == "${src}":
+			include.path = objectPackage(source)
+			include.direct = true
+		case strings.HasPrefix(path, "$(src)/"):
+			include.path = filepath.ToSlash(filepath.Join(objectPackage(source), strings.TrimPrefix(path, "$(src)/")))
+			include.direct = true
+		case strings.HasPrefix(path, "${src}/"):
+			include.path = filepath.ToSlash(filepath.Join(objectPackage(source), strings.TrimPrefix(path, "${src}/")))
+			include.direct = true
+		case strings.HasPrefix(path, "$(obj)/"), strings.HasPrefix(path, "${obj}/"):
+			rest := strings.TrimPrefix(strings.TrimPrefix(path, "$(obj)/"), "${obj}/")
+			include.path = filepath.ToSlash(filepath.Join(objectPackage(source), rest))
+			include.direct = true
+		default:
+			include.path = path
+		}
+		includes = append(includes, include)
+	}
+	return includes
+}
+
+func sourceIncludeFlagsComplete(flags []string) bool {
+	known := []string{"-I", "-iquote", "-isystem", "-idirafter", "-include", "-imacros"}
+	for i := 0; i < len(flags); i++ {
+		flag := flags[i]
+		matched := false
+		for _, option := range known {
+			if flag == option {
+				if i+1 >= len(flags) {
+					return false
+				}
+				value := flags[i+1]
+				if sourceFlagPathUnresolved(value) {
+					return false
+				}
+				i++
+				matched = true
+				break
+			}
+			if value, ok := strings.CutPrefix(flag, option); ok && value != "" {
+				if sourceFlagPathUnresolved(strings.TrimPrefix(value, "=")) {
+					return false
+				}
+				matched = true
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+		for _, prefix := range []string{
+			"-F",
+			"-iframework",
+			"-iprefix",
+			"-iwithprefix",
+			"-Wp,-I",
+			"-Wp,-include",
+			"-Wp,-imacros",
+			"--include",
+			"--imacros",
+			"-Xclang",
+		} {
+			if strings.HasPrefix(flag, prefix) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func sourceFlagPathUnresolved(path string) bool {
+	path = strings.TrimSpace(path)
+	if !strings.Contains(path, "$(") && !strings.Contains(path, "${") {
+		return false
+	}
+	for _, prefix := range []string{
+		"$(src)",
+		"$(srctree)",
+		"${src}",
+		"${srctree}",
+	} {
+		if path == prefix {
+			return false
+		}
+		if strings.HasPrefix(path, prefix+"/") {
+			rest := strings.TrimPrefix(path, prefix+"/")
+			return strings.Contains(rest, "$(") || strings.Contains(rest, "${")
+		}
+	}
+	return true
+}
+
+func flagOptionValues(flags []string, options ...string) []string {
+	var values []string
+	for i := 0; i < len(flags); i++ {
+		for _, option := range options {
+			if flags[i] == option {
+				if i+1 < len(flags) {
+					values = append(values, strings.TrimSpace(flags[i+1]))
+					i++
+				}
+				break
+			}
+			if value, ok := strings.CutPrefix(flags[i], option); ok && value != "" {
+				values = append(values, strings.TrimPrefix(strings.TrimSpace(value), "="))
+				break
+			}
+		}
+	}
+	return values
+}
+
+func sourceTreeFlagPaths(path, source string) []string {
+	path = strings.TrimSpace(path)
+	if sourceFlagPathUnresolved(path) {
+		return nil
+	}
+	switch {
+	case path == "$(srctree)", path == "${srctree}":
+		return []string{""}
+	case strings.HasPrefix(path, "$(srctree)/"):
+		return []string{strings.TrimPrefix(path, "$(srctree)/")}
+	case strings.HasPrefix(path, "${srctree}/"):
+		return []string{strings.TrimPrefix(path, "${srctree}/")}
+	case path == "$(src)", path == "${src}", path == "$(obj)", path == "${obj}":
+		return []string{objectPackage(source)}
+	case strings.HasPrefix(path, "$(src)/"):
+		return []string{filepath.ToSlash(filepath.Join(objectPackage(source), strings.TrimPrefix(path, "$(src)/")))}
+	case strings.HasPrefix(path, "${src}/"):
+		return []string{filepath.ToSlash(filepath.Join(objectPackage(source), strings.TrimPrefix(path, "${src}/")))}
+	case strings.HasPrefix(path, "$(obj)/"):
+		return []string{filepath.ToSlash(filepath.Join(objectPackage(source), strings.TrimPrefix(path, "$(obj)/")))}
+	case strings.HasPrefix(path, "${obj}/"):
+		return []string{filepath.ToSlash(filepath.Join(objectPackage(source), strings.TrimPrefix(path, "${obj}/")))}
+	case path == "" || strings.Contains(path, "$(") || strings.Contains(path, "${") || filepath.IsAbs(filepath.FromSlash(path)):
+		return nil
+	default:
+		return []string{filepath.ToSlash(filepath.Clean(filepath.FromSlash(path)))}
+	}
+}
+
+func (o resolvedKbuildObject) variant(config *ResolvedConfig, source string, sourceIncludes []string, sourceIncludesComplete bool, members, deps []string, sourceRoot string, sourceRefs []string, v012 bool) CompactObjectVariant {
 	fragment := map[string]string{}
 	refset := make(map[string]bool, len(o.footprint)+len(sourceRefs))
 	for ref := range o.footprint {
@@ -1071,7 +1245,7 @@ func (o resolvedKbuildObject) variant(config *ResolvedConfig, source string, sou
 				refset[ref] = true
 			}
 		}
-		if objectNeedsFullConfig(o.object) {
+		if objectNeedsFullConfig(o.object) || (source != "" && !sourceIncludesComplete) {
 			for key, written := range config.Written {
 				if written {
 					refset[key] = true
@@ -1093,6 +1267,8 @@ func (o resolvedKbuildObject) variant(config *ResolvedConfig, source string, sou
 	}
 	flags := normalizeSourceRootFlags(filterResolvedKbuildFlags(o.flags, source), sourceRoot)
 	remove := normalizeSourceRootFlags(filterResolvedKbuildFlags(o.remove, source), sourceRoot)
+	sourceIncludesTracked := v012 && source != ""
+	sourceIncludesIncomplete := sourceIncludesTracked && !sourceIncludesComplete
 	hash := objectVariantHash(
 		o.object,
 		o.mode,
@@ -1101,6 +1277,7 @@ func (o resolvedKbuildObject) variant(config *ResolvedConfig, source string, sou
 		remove,
 		fragment,
 		sourceIncludes,
+		sourceIncludesIncomplete,
 		deps,
 		members,
 		o.root && o.mode == "m",
@@ -1109,22 +1286,23 @@ func (o resolvedKbuildObject) variant(config *ResolvedConfig, source string, sou
 		o.objtoolArgs,
 	)
 	return CompactObjectVariant{
-		Target:          sanitizeTargetName(strings.TrimSuffix(o.object, ".o")) + "__" + hash,
-		Package:         objectPackage(o.object),
-		Object:          o.object,
-		Source:          source,
-		SourceIncludes:  append([]string(nil), sourceIncludes...),
-		Mode:            o.mode,
-		ModuleRoot:      o.root && o.mode == "m",
-		ModName:         o.modname,
-		Flags:           flags,
-		RemoveFlags:     remove,
-		ObjtoolArgs:     append([]string(nil), o.objtoolArgs...),
-		ObjtoolDisabled: o.objtoolDisabled,
-		ObjtoolForce:    o.objtoolForce,
-		ConfigFragment:  fragment,
-		Deps:            append([]string(nil), deps...),
-		Members:         append([]string(nil), members...),
+		Target:                 sanitizeTargetName(strings.TrimSuffix(o.object, ".o")) + "__" + hash,
+		Package:                objectPackage(o.object),
+		Object:                 o.object,
+		Source:                 source,
+		SourceIncludes:         append([]string(nil), sourceIncludes...),
+		SourceIncludesComplete: sourceIncludesTracked && sourceIncludesComplete,
+		Mode:                   o.mode,
+		ModuleRoot:             o.root && o.mode == "m",
+		ModName:                o.modname,
+		Flags:                  flags,
+		RemoveFlags:            remove,
+		ObjtoolArgs:            append([]string(nil), o.objtoolArgs...),
+		ObjtoolDisabled:        o.objtoolDisabled,
+		ObjtoolForce:           o.objtoolForce,
+		ConfigFragment:         fragment,
+		Deps:                   append([]string(nil), deps...),
+		Members:                append([]string(nil), members...),
 	}
 }
 
@@ -1159,7 +1337,7 @@ func normalizeSourceRootFlag(flag, sourceRoot string) string {
 	if strings.HasPrefix(flag, sourceRoot+"/") {
 		return "$(srctree)/" + strings.TrimPrefix(flag, sourceRoot+"/")
 	}
-	for _, prefix := range []string{"-I", "-iquote", "-isystem", "-include"} {
+	for _, prefix := range []string{"-I", "-iquote", "-isystem", "-idirafter", "-include", "-imacros"} {
 		path := strings.TrimPrefix(flag, prefix)
 		if path == flag {
 			continue
@@ -1382,7 +1560,7 @@ func objectPackage(object string) string {
 	return dir
 }
 
-func objectVariantHash(object, mode, modname string, flags, removeFlags []string, fragment map[string]string, sourceIncludes, deps, members []string, moduleRoot, objtoolDisabled, objtoolForce bool, objtoolArgs []string) string {
+func objectVariantHash(object, mode, modname string, flags, removeFlags []string, fragment map[string]string, sourceIncludes []string, sourceIncludesIncomplete bool, deps, members []string, moduleRoot, objtoolDisabled, objtoolForce bool, objtoolArgs []string) string {
 	var b strings.Builder
 	b.WriteString(object)
 	b.WriteByte('\n')
@@ -1423,6 +1601,9 @@ func objectVariantHash(object, mode, modname string, flags, removeFlags []string
 		b.WriteString("source_include=")
 		b.WriteString(include)
 		b.WriteByte('\n')
+	}
+	if sourceIncludesIncomplete {
+		b.WriteString("source_includes=incomplete\n")
 	}
 	for _, dep := range deps {
 		b.WriteString("dep=")
@@ -1594,13 +1775,20 @@ func (m *CompactMetadata) ObjectBuildFile(opts CompactBuildFileOptions) ([]byte,
 		if emitSource {
 			r.SetAttr("src", labelForSource(opts, variant.Source))
 			if opts.Schema.isV012() {
-				r.SetAttr("source_includes_complete", true)
+				if variant.SourceIncludesComplete {
+					r.SetAttr("source_includes_complete", true)
+				}
 				if len(variant.SourceIncludes) != 0 {
 					sourceIncludes := make([]string, 0, len(variant.SourceIncludes))
 					for _, include := range variant.SourceIncludes {
+						if sourceIncludeCoveredByClasses(opts, include) {
+							continue
+						}
 						sourceIncludes = append(sourceIncludes, labelForSource(opts, include))
 					}
-					r.SetAttr("source_includes", sourceIncludes)
+					if len(sourceIncludes) != 0 {
+						r.SetAttr("source_includes", sourceIncludes)
+					}
 				}
 			}
 			if opts.SourceConfig != "" {
@@ -1688,6 +1876,18 @@ func labelForSource(opts CompactBuildFileOptions, source string) string {
 		}
 	}
 	return labelFor(opts.SourceLabelPackage, source)
+}
+
+func sourceIncludeCoveredByClasses(opts CompactBuildFileOptions, source string) bool {
+	if !strings.HasSuffix(source, ".h") {
+		return false
+	}
+	if len(opts.SourceTreeGlobalHeaders) != 0 && strings.HasPrefix(source, "include/") {
+		return true
+	}
+	return len(opts.SourceTreeArchHeaders) != 0 &&
+		opts.Srcarch != "" &&
+		strings.HasPrefix(source, "arch/"+opts.Srcarch+"/include/")
 }
 
 func (m *CompactMetadata) objectBuildFileNeedsConfig(opts CompactBuildFileOptions) bool {

--- a/internal/kconfig/compact_test.go
+++ b/internal/kconfig/compact_test.go
@@ -2,6 +2,7 @@ package kconfig
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1184,10 +1185,17 @@ func TestCompactMetadataJSONMatchesPrettierArrayLayout(t *testing.T) {
 }
 
 func TestNormalizeSourceRootFlagsWindowsPaths(t *testing.T) {
+	root := `C:\users\runneradmin\execroot\external\linux`
 	got := normalizeSourceRootFlags([]string{
 		`-includeC:\users\runneradmin\execroot\external\linux\include\linux\hidden.h`,
-	}, `C:\users\runneradmin\execroot\external\linux`)
-	want := []string{`-include$(srctree)/include/linux/hidden.h`}
+		`-imacrosC:\users\runneradmin\execroot\external\linux\include\linux\macros.h`,
+		`-idirafterC:\users\runneradmin\execroot\external\linux\private`,
+	}, root)
+	want := []string{
+		`-include$(srctree)/include/linux/hidden.h`,
+		`-imacros$(srctree)/include/linux/macros.h`,
+		`-idirafter$(srctree)/private`,
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("normalizeSourceRootFlags() = %#v, want %#v", got, want)
 	}
@@ -1326,23 +1334,38 @@ func TestCompactObjectBuildFileEmitsSourceInputs(t *testing.T) {
 	}
 }
 
-func TestCompactObjectBuildFileEmitsQuotedIncludeClosure(t *testing.T) {
+func TestCompactObjectBuildFileEmitsLiteralIncludeClosure(t *testing.T) {
 	tree := mustParseCompactFixture(t)
-	kb, err := ParseKbuild(strings.NewReader("obj-y += init.o entry.o\n"), "Kbuild")
+	kb, err := ParseKbuild(strings.NewReader("obj-y += init.o entry.o dynamic.o\n"), "Kbuild")
 	if err != nil {
 		t.Fatalf("ParseKbuild() failed: %v", err)
 	}
 	sourceRoot := t.TempDir()
-	mustWriteSource(t, sourceRoot, "init.c", `#include "fragments/first.inc"`+"\n")
+	mustWriteSource(t, sourceRoot, "init.c", `
+#include "fragments/first.inc"
+#include "private/first.h"
+#include <linux/global.h>
+#include <asm/arch.h>
+`)
 	mustWriteSource(t, sourceRoot, "fragments/first.inc", `#include "../shared/second.inc"`+"\n")
+	mustWriteSource(t, sourceRoot, "private/first.h", `#include "nested/second.h"`+"\n")
+	mustWriteSource(t, sourceRoot, "private/nested/second.h", "int private_second;\n")
+	mustWriteSource(t, sourceRoot, "include/linux/global.h", "int global;\n")
+	mustWriteSource(t, sourceRoot, "arch/x86/include/asm/arch.h", "int arch;\n")
 	mustWriteSource(t, sourceRoot, "entry.S", `#include "asm/entry.inc"`+"\n")
 	mustWriteSource(t, sourceRoot, "asm/entry.inc", `#include "../shared/second.inc"`+"\n")
+	mustWriteSource(t, sourceRoot, "dynamic.c", `#include DYNAMIC_HEADER`+"\n")
 	mustWriteSource(t, sourceRoot, "shared/second.inc", "int second;\n")
 	mustWriteSource(t, sourceRoot, "shared/unrelated.inc", "int unrelated;\n")
 
 	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
 		{Name: "base", Flags: nil},
-	}, CompactMetadataOptions{Schema: CompactSchemaV012, SourceRoot: sourceRoot})
+	}, CompactMetadataOptions{
+		Schema:                          CompactSchemaV012,
+		SourceRoot:                      sourceRoot,
+		SourceGeneratedIncludesComplete: true,
+		Srcarch:                         "x86",
+	})
 	if err != nil {
 		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
 	}
@@ -1350,19 +1373,37 @@ func TestCompactObjectBuildFileEmitsQuotedIncludeClosure(t *testing.T) {
 	variants := map[string]CompactObjectVariant{}
 	for object, wantIncludes := range map[string][]string{
 		"entry.o": {"asm/entry.inc", "shared/second.inc"},
-		"init.o":  {"fragments/first.inc", "shared/second.inc"},
+		"init.o": {
+			"arch/x86/include/asm/arch.h",
+			"fragments/first.inc",
+			"include/linux/global.h",
+			"private/first.h",
+			"private/nested/second.h",
+			"shared/second.inc",
+		},
 	} {
 		variant := variantByTarget(metadata, objectTarget(metadata, config, object))
 		if !reflect.DeepEqual(variant.SourceIncludes, wantIncludes) {
 			t.Fatalf("%s SourceIncludes = %v, want %v", object, variant.SourceIncludes, wantIncludes)
 		}
+		if !variant.SourceIncludesComplete {
+			t.Fatalf("%s literal include closure is marked incomplete", object)
+		}
 		variants[object] = variant
 	}
+	dynamic := variantByTarget(metadata, objectTarget(metadata, config, "dynamic.o"))
+	if dynamic.SourceIncludesComplete {
+		t.Fatal("dynamic.o computed include closure is marked complete")
+	}
+	variants["dynamic.o"] = dynamic
 
 	objectBuild, err := metadata.ObjectBuildFile(CompactBuildFileOptions{
-		Schema:             CompactSchemaV012,
-		SourceLabelPackage: "@linux//",
-		SourceRootLabel:    "@linux//:Kconfig",
+		Schema:                  CompactSchemaV012,
+		SourceLabelPackage:      "@linux//",
+		SourceRootLabel:         "@linux//:Kconfig",
+		SourceTreeArchHeaders:   []string{"@linux//:x86_headers"},
+		SourceTreeGlobalHeaders: []string{"@linux//:global_headers"},
+		Srcarch:                 "x86",
 	})
 	if err != nil {
 		t.Fatalf("ObjectBuildFile() failed: %v", err)
@@ -1373,7 +1414,12 @@ func TestCompactObjectBuildFileEmitsQuotedIncludeClosure(t *testing.T) {
 	}
 	for object, wantIncludes := range map[string][]string{
 		"entry.o": {"@linux//:asm/entry.inc", "@linux//:shared/second.inc"},
-		"init.o":  {"@linux//:fragments/first.inc", "@linux//:shared/second.inc"},
+		"init.o": {
+			"@linux//:fragments/first.inc",
+			"@linux//:private/first.h",
+			"@linux//:private/nested/second.h",
+			"@linux//:shared/second.inc",
+		},
 	} {
 		rule := parsed.RuleNamed(variants[object].Target)
 		if rule == nil {
@@ -1385,6 +1431,50 @@ func TestCompactObjectBuildFileEmitsQuotedIncludeClosure(t *testing.T) {
 		if got := rule.AttrLiteral("source_includes_complete"); got != "True" {
 			t.Fatalf("%s source_includes_complete = %q, want True", object, got)
 		}
+	}
+	dynamicRule := parsed.RuleNamed(variants["dynamic.o"].Target)
+	if dynamicRule == nil {
+		t.Fatalf("generated object BUILD missing %q:\n%s", variants["dynamic.o"].Target, objectBuild)
+	}
+	if got := dynamicRule.AttrLiteral("source_includes_complete"); got != "" {
+		t.Fatalf("dynamic.o source_includes_complete = %q, want omitted fallback", got)
+	}
+}
+
+func TestSourceIncludeCoveredByClasses(t *testing.T) {
+	opts := CompactBuildFileOptions{
+		SourceTreeArchHeaders:   []string{"@linux//:x86_headers"},
+		SourceTreeGlobalHeaders: []string{"@linux//:global_headers"},
+		Srcarch:                 "x86",
+	}
+	for source, want := range map[string]bool{
+		"arch/arm64/include/asm/page.h": false,
+		"arch/x86/include/asm/page.h":   true,
+		"drivers/net/private.h":         false,
+		"include/linux/private.h":       true,
+		"include/linux/source.inc":      false,
+	} {
+		if got := sourceIncludeCoveredByClasses(opts, source); got != want {
+			t.Errorf("sourceIncludeCoveredByClasses(%q) = %v, want %v", source, got, want)
+		}
+	}
+	if sourceIncludeCoveredByClasses(CompactBuildFileOptions{Srcarch: "x86"}, "include/linux/private.h") {
+		t.Fatal("source include was filtered without a matching source-tree class")
+	}
+}
+
+func TestCompactObjectVariantMissingCompletenessFailsClosed(t *testing.T) {
+	var variant CompactObjectVariant
+	if err := json.Unmarshal([]byte(`{
+		"target": "init",
+		"object": "init.o",
+		"source": "init.c",
+		"mode": "y"
+	}`), &variant); err != nil {
+		t.Fatalf("json.Unmarshal() failed: %v", err)
+	}
+	if variant.SourceIncludesComplete {
+		t.Fatal("legacy compact metadata without completeness was treated as complete")
 	}
 }
 

--- a/internal/kconfig/config_footprint.go
+++ b/internal/kconfig/config_footprint.go
@@ -1,6 +1,7 @@
 package kconfig
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -20,15 +21,23 @@ type configSourceScanner struct {
 	sourceRoot   string
 	sourceRoots  map[string]string
 	includeRoots []string
+	generated    map[string][]string
 
-	fileRefs map[string][]string
-	fileIncs map[string][]string
-	closure  map[string]sourceClosure
+	fileRefs        map[string][]string
+	fileIncs        map[string][]string
+	fileDynamicIncs map[string][]string
+	closure         map[string]sourceClosure
 }
 
 type sourceClosure struct {
-	refs           []string
-	sourceIncludes []string
+	refs                   []string
+	sourceIncludes         []string
+	sourceIncludesComplete bool
+}
+
+type sourceForcedInclude struct {
+	path   string
+	direct bool
 }
 
 func newConfigSourceScanner(opts CompactMetadataOptions) *configSourceScanner {
@@ -40,12 +49,14 @@ func newConfigSourceScanner(opts CompactMetadataOptions) *configSourceScanner {
 		)
 	}
 	return &configSourceScanner{
-		sourceRoot:   opts.SourceRoot,
-		sourceRoots:  opts.SourceRoots,
-		includeRoots: roots,
-		fileRefs:     map[string][]string{},
-		fileIncs:     map[string][]string{},
-		closure:      map[string]sourceClosure{},
+		sourceRoot:      opts.SourceRoot,
+		sourceRoots:     opts.SourceRoots,
+		includeRoots:    roots,
+		generated:       opts.SourceGeneratedIncludes,
+		fileRefs:        map[string][]string{},
+		fileIncs:        map[string][]string{},
+		fileDynamicIncs: map[string][]string{},
+		closure:         map[string]sourceClosure{},
 	}
 }
 
@@ -53,21 +64,67 @@ func newConfigSourceScanner(opts CompactMetadataOptions) *configSourceScanner {
 // extraIncludeRoots contains tree-relative directories extracted from the
 // object's Kbuild -I flags.
 func (s *configSourceScanner) refsForSource(source string, extraIncludeRoots []string) []string {
-	return append([]string(nil), s.closureForSource(source, extraIncludeRoots).refs...)
+	return append([]string(nil), s.closureForSource(source, extraIncludeRoots, nil, false).refs...)
 }
 
-// sourceIncludesForSource returns sorted source-like tree paths reached through
-// literal includes. It follows the full include graph so source fragments
-// included by a header are also explicit compile-action inputs.
-func (s *configSourceScanner) sourceIncludesForSource(source string, extraIncludeRoots []string) []string {
-	return append([]string(nil), s.closureForSource(source, extraIncludeRoots).sourceIncludes...)
+func (s *configSourceScanner) closureForPreincludes(source string, extraIncludeRoots []string, sourceSearchComplete bool) sourceClosure {
+	refset := map[string]bool{}
+	includeSet := map[string]bool{}
+	complete := true
+	for _, path := range sourcePreincludePaths(source) {
+		if _, ok := s.absForTreePath(path); !ok {
+			continue
+		}
+		closure := s.closureForSource(path, extraIncludeRoots, nil, sourceSearchComplete)
+		if !closure.sourceIncludesComplete {
+			complete = false
+		}
+		for _, ref := range closure.refs {
+			refset[ref] = true
+		}
+		for _, include := range closure.sourceIncludes {
+			includeSet[include] = true
+		}
+	}
+	refs := make([]string, 0, len(refset))
+	for ref := range refset {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	includes := make([]string, 0, len(includeSet))
+	for include := range includeSet {
+		includes = append(includes, include)
+	}
+	sort.Strings(includes)
+	return sourceClosure{
+		refs:                   refs,
+		sourceIncludes:         includes,
+		sourceIncludesComplete: complete,
+	}
 }
 
-func (s *configSourceScanner) closureForSource(source string, extraIncludeRoots []string) sourceClosure {
+// sourceIncludesForSource returns sorted source-tree paths reached through
+// recursively resolved literal includes. The boolean is false when the closure
+// contains an unresolved computed include that requires the blanket fallback.
+func (s *configSourceScanner) sourceIncludesForSource(source string, extraIncludeRoots []string) ([]string, bool) {
+	closure := s.closureForSource(source, extraIncludeRoots, nil, false)
+	return append([]string(nil), closure.sourceIncludes...), closure.sourceIncludesComplete
+}
+
+// sourceSearchComplete means every source-tree include search root used by the
+// compile action is represented by extraIncludeRoots. An unresolved literal is
+// then generated, toolchain-provided, inactive, or a compile error rather than
+// an omitted source-tree input.
+func (s *configSourceScanner) closureForSource(source string, extraIncludeRoots []string, forcedIncludes []sourceForcedInclude, sourceSearchComplete bool) sourceClosure {
 	if s == nil || source == "" {
 		return sourceClosure{}
 	}
-	key := source + "\x00" + strings.Join(extraIncludeRoots, "\x00")
+	keyParts := append([]string{source}, extraIncludeRoots...)
+	for _, include := range forcedIncludes {
+		keyParts = append(keyParts, include.path, fmt.Sprintf("direct=%t", include.direct))
+	}
+	keyParts = append(keyParts, fmt.Sprintf("source_search_complete=%t", sourceSearchComplete))
+	key := strings.Join(keyParts, "\x00")
 	if cached, ok := s.closure[key]; ok {
 		return cached
 	}
@@ -84,7 +141,20 @@ func (s *configSourceScanner) closureForSource(source string, extraIncludeRoots 
 	refset := map[string]bool{}
 	includeSet := map[string]bool{}
 	visited := map[string]bool{}
+	sourceIncludesComplete := true
 	stack := []string{source}
+	for _, include := range forcedIncludes {
+		resolved, satisfied := s.resolveForcedInclude(source, include, extraIncludeRoots)
+		if !satisfied {
+			sourceIncludesComplete = false
+		}
+		for _, path := range resolved {
+			if path != source {
+				includeSet[path] = true
+			}
+			stack = append(stack, path)
+		}
+	}
 	for len(stack) > 0 {
 		treePath := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -96,13 +166,20 @@ func (s *configSourceScanner) closureForSource(source string, extraIncludeRoots 
 		if !ok {
 			continue
 		}
-		refs, rawIncludes := s.scanFile(abs)
+		refs, rawIncludes, dynamicIncludes := s.scanFile(abs)
+		if len(dynamicIncludes) != 0 {
+			sourceIncludesComplete = false
+		}
 		for _, ref := range refs {
 			refset[ref] = true
 		}
 		for _, inc := range rawIncludes {
-			for _, resolved := range s.resolveInclude(treePath, inc, extraIncludeRoots) {
-				if resolved != source && isSourceLikeInclude(resolved) {
+			resolvedIncludes, satisfied := s.resolveLiteralInclude(treePath, inc, extraIncludeRoots)
+			if !satisfied && !sourceSearchComplete {
+				sourceIncludesComplete = false
+			}
+			for _, resolved := range resolvedIncludes {
+				if resolved != source {
 					includeSet[resolved] = true
 				}
 				if !visited[resolved] {
@@ -122,18 +199,69 @@ func (s *configSourceScanner) closureForSource(source string, extraIncludeRoots 
 	}
 	sort.Strings(includes)
 	result := sourceClosure{
-		refs:           out,
-		sourceIncludes: includes,
+		refs:                   out,
+		sourceIncludes:         includes,
+		sourceIncludesComplete: sourceIncludesComplete,
 	}
 	s.closure[key] = result
 	return result
 }
 
-func isSourceLikeInclude(path string) bool {
-	return strings.HasSuffix(path, ".c") ||
-		strings.HasSuffix(path, ".S") ||
-		strings.HasSuffix(path, ".s") ||
-		strings.HasSuffix(path, ".inc")
+func sourcePreincludePaths(source string) []string {
+	paths := []string{
+		"include/linux/compiler-version.h",
+		"include/linux/kconfig.h",
+	}
+	if filepath.Ext(source) == ".c" || strings.HasSuffix(source, ".c_shipped") {
+		paths = append(paths, "include/linux/compiler_types.h")
+	}
+	return paths
+}
+
+func (s *configSourceScanner) resolveForcedInclude(source string, include sourceForcedInclude, extraRoots []string) ([]string, bool) {
+	if include.direct {
+		path, ok := cleanSourceTreePath(include.path)
+		if !ok {
+			return nil, false
+		}
+		if _, ok := s.absForTreePath(path); ok {
+			return []string{path}, true
+		}
+		return s.resolveGeneratedInclude(path)
+	}
+	return s.resolveLiteralInclude(source, include.path, extraRoots)
+}
+
+func (s *configSourceScanner) resolveLiteralInclude(fromTreePath, include string, extraRoots []string) ([]string, bool) {
+	resolved := s.resolveInclude(fromTreePath, include, extraRoots)
+	include = filepath.ToSlash(filepath.Clean(filepath.FromSlash(strings.TrimSpace(include))))
+	generated, generatedSatisfied := s.resolveGeneratedInclude(include)
+	for _, path := range generated {
+		resolved = appendUnique(resolved, path)
+	}
+	return resolved, len(resolved) != 0 || generatedSatisfied
+}
+
+func (s *configSourceScanner) resolveGeneratedInclude(include string) ([]string, bool) {
+	backings, ok := s.generated[include]
+	if !ok {
+		return nil, false
+	}
+	if len(backings) == 0 {
+		return nil, true
+	}
+	resolved := make([]string, 0, len(backings))
+	for _, backing := range backings {
+		backing, ok := cleanSourceTreePath(backing)
+		if !ok {
+			return nil, false
+		}
+		if _, ok := s.absForTreePath(backing); !ok {
+			return nil, false
+		}
+		resolved = appendUnique(resolved, backing)
+	}
+	return resolved, true
 }
 
 // refsForSourceDir returns the union of CONFIG_* footprints of every C and
@@ -170,27 +298,36 @@ func (s *configSourceScanner) refsForSourceDir(dir string) []string {
 	return out
 }
 
-// scanFile returns the CONFIG_* tokens and raw include targets of one file.
-func (s *configSourceScanner) scanFile(abs string) (refs, rawIncludes []string) {
+// scanFile returns the CONFIG_* tokens and literal and computed include
+// targets of one file.
+func (s *configSourceScanner) scanFile(abs string) (refs, rawIncludes, dynamicIncludes []string) {
 	if cached, ok := s.fileRefs[abs]; ok {
-		return cached, s.fileIncs[abs]
+		return cached, s.fileIncs[abs], s.fileDynamicIncs[abs]
 	}
 	data, err := os.ReadFile(abs)
 	if err != nil {
 		s.fileRefs[abs] = nil
 		s.fileIncs[abs] = nil
-		return nil, nil
+		s.fileDynamicIncs[abs] = []string{""}
+		return nil, nil, []string{""}
 	}
 	text := string(data)
 	refs = configRefs(text)
-	for _, line := range strings.Split(text, "\n") {
-		if inc, ok := includePath(line); ok {
+	for _, line := range preprocessorLines(text) {
+		inc, literal, directive := includeDirective(line)
+		if literal {
 			rawIncludes = append(rawIncludes, inc)
+		} else if directive {
+			dynamicIncludes = append(dynamicIncludes, inc)
+		}
+		if assemblerIncbinDirective(line) {
+			dynamicIncludes = append(dynamicIncludes, ".incbin")
 		}
 	}
 	s.fileRefs[abs] = refs
 	s.fileIncs[abs] = rawIncludes
-	return refs, rawIncludes
+	s.fileDynamicIncs[abs] = dynamicIncludes
+	return refs, rawIncludes, dynamicIncludes
 }
 
 // resolveInclude returns every existing tree path an include could name.
@@ -217,32 +354,17 @@ func (s *configSourceScanner) resolveInclude(fromTreePath, inc string, extraRoot
 	if fromTreePath != "" {
 		add(filepath.ToSlash(filepath.Join(filepath.Dir(fromTreePath), filepath.FromSlash(inc))))
 	}
-	for _, candidate := range includeCandidates(inc) {
-		for _, root := range s.includeRoots {
-			add(root + "/" + candidate)
-		}
-		for _, root := range extraRoots {
-			if root == "" {
-				add(candidate)
-			} else {
-				add(root + "/" + candidate)
-			}
+	for _, root := range s.includeRoots {
+		add(root + "/" + inc)
+	}
+	for _, root := range extraRoots {
+		if root == "" {
+			add(inc)
+		} else {
+			add(root + "/" + inc)
 		}
 	}
 	return out
-}
-
-// includeCandidates maps generated per-arch asm wrappers to their source-tree
-// asm-generic counterparts as an additional conservative scan target.
-func includeCandidates(inc string) []string {
-	inc = filepath.ToSlash(inc)
-	candidates := []string{inc}
-	if rest, ok := strings.CutPrefix(inc, "asm/"); ok {
-		candidates = append(candidates, "asm-generic/"+rest)
-	} else if rest, ok := strings.CutPrefix(inc, "uapi/asm/"); ok {
-		candidates = append(candidates, "uapi/asm-generic/"+rest)
-	}
-	return candidates
 }
 
 func (s *configSourceScanner) absForTreePath(path string) (string, bool) {
@@ -270,26 +392,23 @@ func cleanSourceTreePath(path string) (string, bool) {
 	return path, true
 }
 
-// includePath extracts a literal quoted or angled C preprocessor include.
-func includePath(line string) (string, bool) {
+// includeDirective distinguishes literal and computed C preprocessor includes.
+func includeDirective(line string) (target string, literal, directive bool) {
 	line = strings.TrimSpace(line)
 	if !strings.HasPrefix(line, "#") {
-		return "", false
+		return "", false, false
 	}
 	line = strings.TrimSpace(line[1:])
-	if !strings.HasPrefix(line, "include") {
-		return "", false
+	if rest, ok := directiveKeywordRest(line, "include_next"); ok {
+		return strings.TrimSpace(rest), false, true
 	}
-	rest := line[len("include"):]
-	if rest == "" {
-		return "", false
-	}
-	if c := rest[0]; c != '"' && c != '<' && c != ' ' && c != '\t' {
-		return "", false
+	rest, ok := directiveKeywordRest(line, "include")
+	if !ok {
+		return "", false, false
 	}
 	rest = strings.TrimSpace(rest)
 	if rest == "" {
-		return "", false
+		return "", false, true
 	}
 	var closeByte byte
 	switch rest[0] {
@@ -298,12 +417,101 @@ func includePath(line string) (string, bool) {
 	case '<':
 		closeByte = '>'
 	default:
-		return "", false
+		return strings.TrimSpace(rest), false, true
 	}
 	rest = rest[1:]
 	end := strings.IndexByte(rest, closeByte)
 	if end < 0 {
+		return "", false, true
+	}
+	return rest[:end], true, true
+}
+
+func assemblerIncbinDirective(line string) bool {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, ".incbin") {
+		return false
+	}
+	rest := strings.TrimPrefix(line, ".incbin")
+	return rest == "" || strings.ContainsAny(rest[:1], " \t\v\f\r\"")
+}
+
+func directiveKeywordRest(line, keyword string) (string, bool) {
+	if !strings.HasPrefix(line, keyword) {
 		return "", false
 	}
-	return rest[:end], true
+	rest := line[len(keyword):]
+	if rest == "" {
+		return "", true
+	}
+	switch rest[0] {
+	case ' ', '\t', '\v', '\f', '\r', '/', '\\', '"', '<':
+		return rest, true
+	default:
+		return "", false
+	}
+}
+
+func preprocessorLines(text string) []string {
+	text = strings.ReplaceAll(text, "\\\r\n", "")
+	text = strings.ReplaceAll(text, "\\\n", "")
+	var out strings.Builder
+	out.Grow(len(text))
+	const (
+		normal = iota
+		lineComment
+		blockComment
+		stringLiteral
+		charLiteral
+	)
+	state := normal
+	for i := 0; i < len(text); i++ {
+		current := text[i]
+		next := byte(0)
+		if i+1 < len(text) {
+			next = text[i+1]
+		}
+		switch state {
+		case normal:
+			switch {
+			case current == '/' && next == '/':
+				out.WriteByte(' ')
+				i++
+				state = lineComment
+			case current == '/' && next == '*':
+				out.WriteByte(' ')
+				i++
+				state = blockComment
+			case current == '"':
+				out.WriteByte(current)
+				state = stringLiteral
+			case current == '\'':
+				out.WriteByte(current)
+				state = charLiteral
+			default:
+				out.WriteByte(current)
+			}
+		case lineComment:
+			if current == '\n' {
+				out.WriteByte(current)
+				state = normal
+			}
+		case blockComment:
+			if current == '*' && next == '/' {
+				i++
+				state = normal
+			} else if current == '\n' {
+				out.WriteByte(current)
+			}
+		case stringLiteral, charLiteral:
+			out.WriteByte(current)
+			if current == '\\' && i+1 < len(text) {
+				i++
+				out.WriteByte(text[i])
+			} else if (state == stringLiteral && current == '"') || (state == charLiteral && current == '\'') {
+				state = normal
+			}
+		}
+	}
+	return strings.Split(out.String(), "\n")
 }

--- a/internal/kconfig/config_footprint_test.go
+++ b/internal/kconfig/config_footprint_test.go
@@ -1,6 +1,7 @@
 package kconfig
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -8,28 +9,65 @@ import (
 	"testing"
 )
 
-func TestIncludePath(t *testing.T) {
+func TestIncludeDirective(t *testing.T) {
 	cases := []struct {
-		line string
-		want string
-		ok   bool
+		text            string
+		wantPath        string
+		directiveTarget string
+		literal         bool
+		directive       bool
 	}{
-		{`#include "local.h"`, "local.h", true},
-		{`#include <linux/sched.h>`, "linux/sched.h", true},
-		{`#  include   "spaced.h"`, "spaced.h", true},
-		{`#include<linux/nospace.h>`, "linux/nospace.h", true},
-		{`# include <asm/page.h> /* trailing */`, "asm/page.h", true},
-		{`   #include "indented.h"`, "indented.h", true},
-		{`#include MACRO_HEADER`, "", false},
-		{`#included "not-a-directive.h"`, "", false},
-		{`int included = 1;`, "", false},
-		{`// #include "commented.h"`, "", false},
-		{`#define X 1`, "", false},
+		{`#include "local.h"`, "local.h", "local.h", true, true},
+		{`#include <linux/sched.h>`, "linux/sched.h", "linux/sched.h", true, true},
+		{`#  include   "spaced.h"`, "spaced.h", "spaced.h", true, true},
+		{`#include<linux/nospace.h>`, "linux/nospace.h", "linux/nospace.h", true, true},
+		{`# include <asm/page.h> /* trailing */`, "asm/page.h", "asm/page.h", true, true},
+		{`   #include "indented.h"`, "indented.h", "indented.h", true, true},
+		{`/* lead */ #include "leading-comment.h"`, "leading-comment.h", "leading-comment.h", true, true},
+		{"/* lead\n */ #include \"multiline-comment.h\"", "multiline-comment.h", "multiline-comment.h", true, true},
+		{`#/**/include "commented-space.h"`, "commented-space.h", "commented-space.h", true, true},
+		{`#include/**/"commented-target.h"`, "commented-target.h", "commented-target.h", true, true},
+		{"#\\\ninclude \"spliced-directive.h\"", "spliced-directive.h", "spliced-directive.h", true, true},
+		{"#inc\\\nlude \"spliced-keyword.h\"", "spliced-keyword.h", "spliced-keyword.h", true, true},
+		{`#include MACRO_HEADER`, "", "MACRO_HEADER", false, true},
+		{`#/**/include MACRO_HEADER`, "", "MACRO_HEADER", false, true},
+		{`#include/* comment */ MACRO_HEADER`, "", "MACRO_HEADER", false, true},
+		{`#include_next <linux/next.h>`, "", "<linux/next.h>", false, true},
+		{`#include\`, "", `\`, false, true},
+		{`#include`, "", "", false, true},
+		{`#included "not-a-directive.h"`, "", "", false, false},
+		{`int included = 1;`, "", "", false, false},
+		{"#\ninclude \"not-spliced.h\"", "", "", false, false},
+		{`// #include "commented.h"`, "", "", false, false},
+		{`#define X 1`, "", "", false, false},
 	}
 	for _, tc := range cases {
-		got, ok := includePath(tc.line)
-		if ok != tc.ok || got != tc.want {
-			t.Errorf("includePath(%q) = (%q, %v), want (%q, %v)", tc.line, got, ok, tc.want, tc.ok)
+		var got string
+		var literal, directive bool
+		for _, line := range preprocessorLines(tc.text) {
+			got, literal, directive = includeDirective(line)
+			if directive {
+				break
+			}
+		}
+		if got != tc.directiveTarget || literal != tc.literal || directive != tc.directive {
+			t.Errorf(
+				"preprocessed includeDirective(%q) = (%q, %v, %v), want (%q, %v, %v)",
+				tc.text,
+				got,
+				literal,
+				directive,
+				tc.directiveTarget,
+				tc.literal,
+				tc.directive,
+			)
+		}
+		path := ""
+		if literal {
+			path = got
+		}
+		if path != tc.wantPath {
+			t.Errorf("preprocessed include path for %q = %q, want %q", tc.text, path, tc.wantPath)
 		}
 	}
 }
@@ -81,6 +119,7 @@ func TestConfigSourceScannerReturnsRecursiveSourceIncludeClosure(t *testing.T) {
 	root := t.TempDir()
 	mustWriteSource(t, root, "drivers/bpf/prog.c", `
 #include "../../shared/first.inc"
+#include "private/wrapper.h"
 #include <linux/wrapper.h>
 `)
 	mustWriteSource(t, root, "shared/first.inc", `
@@ -95,18 +134,253 @@ func TestConfigSourceScannerReturnsRecursiveSourceIncludeClosure(t *testing.T) {
 #include "../../shared/header-source.inc"
 #include <linux/angled-source.inc>
 `)
+	mustWriteSource(t, root, "drivers/bpf/private/wrapper.h", `#include "nested.h"`+"\n")
+	mustWriteSource(t, root, "drivers/bpf/private/nested.h", "int nested;\n")
 	mustWriteSource(t, root, "shared/unrelated.inc", "int unrelated;\n")
 
 	scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
-	got := scanner.sourceIncludesForSource("drivers/bpf/prog.c", nil)
+	got, complete := scanner.sourceIncludesForSource("drivers/bpf/prog.c", nil)
 	want := []string{
+		"drivers/bpf/private/nested.h",
+		"drivers/bpf/private/wrapper.h",
 		"include/linux/angled-source.inc",
+		"include/linux/wrapper.h",
 		"shared/first.inc",
 		"shared/header-source.inc",
 		"shared/nested/second.inc",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sourceIncludesForSource() = %v, want %v", got, want)
+	}
+	if !complete {
+		t.Fatal("sourceIncludesForSource() unexpectedly marked a literal closure incomplete")
+	}
+}
+
+func TestConfigSourceScannerMarksTraceReincludeIncomplete(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/trace.c", "#include \"trace.h\"\n")
+	mustWriteSource(t, root, "drivers/trace.h", `
+#define TRACE_SYSTEM fixture
+#include <trace/define_trace.h>
+`)
+	mustWriteSource(t, root, "include/trace/define_trace.h", "#include TRACE_INCLUDE(TRACE_INCLUDE_FILE)\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
+	got, complete := scanner.sourceIncludesForSource("drivers/trace.c", nil)
+	want := []string{"drivers/trace.h", "include/trace/define_trace.h"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sourceIncludesForSource() = %v, want %v", got, want)
+	}
+	if complete {
+		t.Fatal("sourceIncludesForSource() assumed the trace macro expansion was already resolved")
+	}
+}
+
+func TestConfigSourceScannerMarksGlobalComputedIncludeIncomplete(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/foo.c", "#include <linux/wrapper.h>\n")
+	mustWriteSource(t, root, "include/linux/wrapper.h", "#include GLOBAL_DYNAMIC_HEADER\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
+	_, complete := scanner.sourceIncludesForSource("drivers/foo.c", nil)
+	if complete {
+		t.Fatal("sourceIncludesForSource() ignored an unknown computed include in a global header")
+	}
+}
+
+func TestConfigSourceScannerMarksComputedIncludeIncomplete(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/foo.c", `
+#include "private.h"
+#include CONFIG_PRIVATE_HEADER
+`)
+	mustWriteSource(t, root, "drivers/private.h", "int private;\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
+	got, complete := scanner.sourceIncludesForSource("drivers/foo.c", nil)
+	if want := []string{"drivers/private.h"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("sourceIncludesForSource() = %v, want %v", got, want)
+	}
+	if complete {
+		t.Fatal("sourceIncludesForSource() marked a computed include complete")
+	}
+}
+
+func TestConfigSourceScannerMarksAssemblerIncbinIncomplete(t *testing.T) {
+	for _, directive := range []string{
+		`.incbin "lib/default.bconf"`,
+		`.incbin CONFIG_EFI_SBAT_FILE`,
+	} {
+		t.Run(directive, func(t *testing.T) {
+			root := t.TempDir()
+			mustWriteSource(t, root, "lib/data.S", directive+"\n")
+			mustWriteSource(t, root, "lib/default.bconf", "kernel.printk = 1\n")
+
+			scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
+			_, complete := scanner.sourceIncludesForSource("lib/data.S", nil)
+			if complete {
+				t.Fatalf("sourceIncludesForSource() marked %q complete", directive)
+			}
+		})
+	}
+}
+
+func TestConfigSourceScannerMarksUnresolvedLiteralIncludeIncomplete(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/foo.c", "#include \"missing-private.h\"\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
+	got, complete := scanner.sourceIncludesForSource("drivers/foo.c", nil)
+	if len(got) != 0 {
+		t.Fatalf("sourceIncludesForSource() = %v, want no resolved includes", got)
+	}
+	if complete {
+		t.Fatal("sourceIncludesForSource() marked an unresolved literal include complete")
+	}
+}
+
+func TestConfigSourceScannerAcceptsUnresolvedNonSourceLiteral(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/foo.c", "#include <generated/value.h>\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
+	closure := scanner.closureForSource("drivers/foo.c", nil, nil, true)
+	if !closure.sourceIncludesComplete {
+		t.Fatal("closureForSource() rejected an unresolved non-source include with a complete source search model")
+	}
+}
+
+func TestCompactMetadataRequiresCompleteGeneratedIncludeManifest(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	root := t.TempDir()
+	kb, err := ParseKbuild(strings.NewReader("obj-y += init.o\n"), "Kbuild")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	mustWriteSource(t, root, "init.c", "#include <generated/value.h>\n")
+
+	for _, test := range []struct {
+		name             string
+		manifestEntry    bool
+		manifestComplete bool
+		wantComplete     bool
+	}{
+		{name: "unspecified manifest"},
+		{name: "exact entry without completeness assertion", manifestEntry: true},
+		{name: "complete manifest", manifestComplete: true, wantComplete: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			generatedIncludes := map[string][]string{}
+			if test.manifestEntry {
+				generatedIncludes["generated/value.h"] = nil
+			}
+			metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
+				{Name: "base", Flags: map[string]string{"CONFIG_NET": "y"}},
+			}, CompactMetadataOptions{
+				Schema:                          CompactSchemaV012,
+				SourceRoot:                      root,
+				SourceGeneratedIncludes:         generatedIncludes,
+				SourceGeneratedIncludesComplete: test.manifestComplete,
+			})
+			if err != nil {
+				t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+			}
+			variant := variantByTarget(metadata, objectTarget(metadata, configByName(metadata, "base"), "init.o"))
+			if variant.SourceIncludesComplete != test.wantComplete {
+				t.Fatalf("SourceIncludesComplete = %t, want %t", variant.SourceIncludesComplete, test.wantComplete)
+			}
+		})
+	}
+}
+
+func TestConfigSourceScannerMarksUnresolvedForcedIncludeIncomplete(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/foo.c", "int foo;\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
+	closure := scanner.closureForSource(
+		"drivers/foo.c",
+		nil,
+		[]sourceForcedInclude{{path: "missing-forced.h"}},
+		false,
+	)
+	if closure.sourceIncludesComplete {
+		t.Fatal("closureForSource() marked an unresolved forced include complete")
+	}
+}
+
+func TestConfigSourceScannerUsesGeneratedManifestForForcedInclude(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/foo.c", "int foo;\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{
+		SourceRoot: root,
+		SourceGeneratedIncludes: map[string][]string{
+			"include/generated/value.h": nil,
+		},
+	})
+	closure := scanner.closureForSource(
+		"drivers/foo.c",
+		nil,
+		[]sourceForcedInclude{{path: "include/generated/value.h"}},
+		false,
+	)
+	if !closure.sourceIncludesComplete {
+		t.Fatal("generated forced include produced an incomplete closure")
+	}
+}
+
+func TestConfigSourceScannerUsesGeneratedIncludeManifest(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/foo.c", `
+#include <asm/wrapper.h>
+#include <generated/value.h>
+`)
+	mustWriteSource(t, root, "include/asm-generic/wrapper.h", "#ifdef CONFIG_WRAPPER\n#endif\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{
+		SourceRoot: root,
+		SourceGeneratedIncludes: map[string][]string{
+			"asm/wrapper.h":     {"include/asm-generic/wrapper.h"},
+			"generated/value.h": nil,
+		},
+	})
+	closure := scanner.closureForSource("drivers/foo.c", nil, nil, false)
+	if want := []string{"include/asm-generic/wrapper.h"}; !reflect.DeepEqual(closure.sourceIncludes, want) {
+		t.Fatalf("SourceIncludes = %v, want %v", closure.sourceIncludes, want)
+	}
+	if want := []string{"CONFIG_WRAPPER"}; !reflect.DeepEqual(closure.refs, want) {
+		t.Fatalf("refs = %v, want %v", closure.refs, want)
+	}
+	if !closure.sourceIncludesComplete {
+		t.Fatal("generated include manifest produced an incomplete closure")
+	}
+}
+
+func TestConfigSourceScannerDoesNotHideGeneratedBackingBehindSourceMatch(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/foo.c", "#include <generated/value.h>\n")
+	mustWriteSource(t, root, "drivers/generated/value.h", "#ifdef CONFIG_SOURCE_MATCH\n#endif\n")
+	mustWriteSource(t, root, "include/generated-backing.h", "#ifdef CONFIG_GENERATED_BACKING\n#endif\n")
+
+	scanner := newConfigSourceScanner(CompactMetadataOptions{
+		SourceRoot: root,
+		SourceGeneratedIncludes: map[string][]string{
+			"generated/value.h": {"include/generated-backing.h"},
+		},
+	})
+	closure := scanner.closureForSource("drivers/foo.c", nil, nil, true)
+	wantIncludes := []string{"drivers/generated/value.h", "include/generated-backing.h"}
+	if !reflect.DeepEqual(closure.sourceIncludes, wantIncludes) {
+		t.Fatalf("SourceIncludes = %v, want %v", closure.sourceIncludes, wantIncludes)
+	}
+	wantRefs := []string{"CONFIG_GENERATED_BACKING", "CONFIG_SOURCE_MATCH"}
+	if !reflect.DeepEqual(closure.refs, wantRefs) {
+		t.Fatalf("refs = %v, want %v", closure.refs, wantRefs)
+	}
+	if !closure.sourceIncludesComplete {
+		t.Fatal("combined source/generated closure was marked incomplete")
 	}
 }
 
@@ -116,11 +390,275 @@ func TestIncludeDirsFromFlags(t *testing.T) {
 		"-I$(srctree)/drivers/foo",
 		"-I",
 		"$(srctree)/include/generated",
+		"-iquote$(src)/private",
+		"-isystem",
+		"vendor/include",
+		"-iquote$(obj)/generated",
+		"-idirafter${srctree}/brace",
 		"-I/absolute/path",
-	})
-	want := []string{"drivers/foo", "include/generated"}
+	}, "drivers/net/foo.c")
+	want := []string{
+		"drivers/foo",
+		"include/generated",
+		"drivers/net/private",
+		"vendor/include",
+		"brace",
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("includeDirsFromFlags() = %v, want %v", got, want)
+	}
+}
+
+func TestForcedIncludesFromFlags(t *testing.T) {
+	got := forcedIncludesFromFlags([]string{
+		"-include",
+		"$(srctree)/include/linux/hidden.h",
+		"-imacros$(src)/private.h",
+		"-include${srctree}/include/linux/brace.h",
+		"-include=$(obj)/utsversion-tmp.h",
+	}, "init/version.c")
+	want := []sourceForcedInclude{
+		{path: "include/linux/hidden.h", direct: true},
+		{path: "init/private.h", direct: true},
+		{path: "include/linux/brace.h", direct: true},
+		{path: "init/utsversion-tmp.h", direct: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("forcedIncludesFromFlags() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSourcePreincludePathsTreatsShippedSourceAsC(t *testing.T) {
+	want := []string{
+		"include/linux/compiler-version.h",
+		"include/linux/kconfig.h",
+		"include/linux/compiler_types.h",
+	}
+	if got := sourcePreincludePaths("drivers/foo.c_shipped"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("sourcePreincludePaths() = %v, want %v", got, want)
+	}
+}
+
+func TestSourceIncludeFlagsComplete(t *testing.T) {
+	for _, flags := range [][]string{
+		nil,
+		{"-I$(srctree)/private", "-iquote", "$(src)", "-include", "$(srctree)/generated.h"},
+		{"-isystem/opt/toolchain/include"},
+	} {
+		if !sourceIncludeFlagsComplete(flags) {
+			t.Errorf("sourceIncludeFlagsComplete(%v) = false, want true", flags)
+		}
+	}
+	for _, flags := range [][]string{
+		{"-I"},
+		{"-I$(UNKNOWN)/private"},
+		{"-I$(srctree)/$(UNKNOWN)"},
+		{"-I${src}/${UNKNOWN}"},
+		{"-include", "$(obj)/generated.h"},
+		{"-iprefix", "$(srctree)/private"},
+		{"-Wp,-I,$(srctree)/private"},
+		{"-Wp,-imacros,$(srctree)/private.h"},
+		{"--include", "$(srctree)/private.h"},
+		{"--imacros=$(srctree)/private.h"},
+		{"-Xclang", "-include"},
+	} {
+		if sourceIncludeFlagsComplete(flags) {
+			t.Errorf("sourceIncludeFlagsComplete(%v) = true, want false", flags)
+		}
+	}
+}
+
+func TestCompactFootprintTreatsObjectDirectoryIncludeAsIncomplete(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	kb, err := ParseKbuild(strings.NewReader(`
+obj-y += init.o
+ccflags-y += -include $(obj)/utsversion-tmp.h
+`), "Kbuild")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	root := t.TempDir()
+	mustWriteSource(t, root, "init.c", "int init;\n")
+	mustWriteSource(t, root, "utsversion-tmp.h", "int source_collision;\n")
+
+	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
+		{Name: "off", Flags: map[string]string{"CONFIG_NET": "y"}},
+		{Name: "on", Flags: map[string]string{"CONFIG_NET": "y", "CONFIG_DEBUG": "y"}},
+	}, CompactMetadataOptions{
+		Schema:                          CompactSchemaV012,
+		SourceRoot:                      root,
+		SourceGeneratedIncludesComplete: true,
+	})
+	if err != nil {
+		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+	}
+	off := objectTarget(metadata, configByName(metadata, "off"), "init.o")
+	on := objectTarget(metadata, configByName(metadata, "on"), "init.o")
+	if off == on {
+		t.Fatalf("generated object-directory include did not retain the full config: both = %q", off)
+	}
+	if variantByTarget(metadata, on).SourceIncludesComplete {
+		t.Fatal("generated object-directory include was marked complete")
+	}
+}
+
+func TestCompactFootprintFollowsIncludeFlags(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	root := t.TempDir()
+	kb, err := ParseKbuild(strings.NewReader(fmt.Sprintf(`
+obj-y += init.o
+ccflags-y += -iquote%s/private -include %s/forced.h
+`, root, root)), "Kbuild")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	mustWriteSource(t, root, "init.c", "#include \"quoted.h\"\n")
+	mustWriteSource(t, root, "private/quoted.h", "int quoted;\n")
+	mustWriteSource(t, root, "forced.h", "#ifdef CONFIG_DEBUG\nint forced;\n#endif\n")
+
+	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
+		{Name: "off", Flags: map[string]string{"CONFIG_NET": "y"}},
+		{Name: "on", Flags: map[string]string{"CONFIG_NET": "y", "CONFIG_DEBUG": "y"}},
+	}, CompactMetadataOptions{
+		Schema:                          CompactSchemaV012,
+		SourceRoot:                      root,
+		SourceGeneratedIncludesComplete: true,
+	})
+	if err != nil {
+		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+	}
+
+	off := objectTarget(metadata, configByName(metadata, "off"), "init.o")
+	on := objectTarget(metadata, configByName(metadata, "on"), "init.o")
+	if off == on {
+		t.Fatalf("forced-header CONFIG_DEBUG did not split init.o: both = %q", off)
+	}
+	variant := variantByTarget(metadata, on)
+	if want := []string{"forced.h", "private/quoted.h"}; !reflect.DeepEqual(variant.SourceIncludes, want) {
+		t.Fatalf("SourceIncludes = %v, want %v (flags: %v)", variant.SourceIncludes, want, variant.Flags)
+	}
+	if !variant.SourceIncludesComplete {
+		t.Fatal("resolved include flags produced an incomplete source closure")
+	}
+	if got := variant.ConfigFragment["CONFIG_DEBUG"]; got != "y" {
+		t.Fatalf("ConfigFragment[CONFIG_DEBUG] = %q, want y", got)
+	}
+}
+
+func TestCompactFootprintScansDefaultPreincludes(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	kb := mustParseKbuildFixture(t)
+	root := t.TempDir()
+	mustWriteSource(t, root, "init.c", "int init;\n")
+	mustWriteSource(t, root, "include/linux/compiler-version.h", "int compiler_version;\n")
+	mustWriteSource(t, root, "include/linux/kconfig.h", "int kconfig;\n")
+	mustWriteSource(t, root, "include/linux/compiler_types.h", "#ifdef CONFIG_DEBUG\nint compiler_type;\n#endif\n")
+
+	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
+		{Name: "off", Flags: map[string]string{"CONFIG_NET": "y"}},
+		{Name: "on", Flags: map[string]string{"CONFIG_NET": "y", "CONFIG_DEBUG": "y"}},
+	}, CompactMetadataOptions{
+		Schema:                          CompactSchemaV012,
+		SourceRoot:                      root,
+		SourceGeneratedIncludesComplete: true,
+	})
+	if err != nil {
+		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+	}
+
+	off := objectTarget(metadata, configByName(metadata, "off"), "init.o")
+	on := objectTarget(metadata, configByName(metadata, "on"), "init.o")
+	if off == on {
+		t.Fatalf("default-preinclude CONFIG_DEBUG did not split init.o: both = %q", off)
+	}
+	variant := variantByTarget(metadata, on)
+	if len(variant.SourceIncludes) != 0 {
+		t.Fatalf("SourceIncludes = %v, want no redundant classified preinclude headers", variant.SourceIncludes)
+	}
+	if !variant.SourceIncludesComplete {
+		t.Fatal("resolved default preincludes produced an incomplete source closure")
+	}
+}
+
+func TestCompactFootprintIncludesDefaultPreincludeClosure(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	root := t.TempDir()
+	kb, err := ParseKbuild(strings.NewReader(fmt.Sprintf(`
+obj-y += init.o
+ccflags-y += -I%s/private
+`, root)), "Kbuild")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	mustWriteSource(t, root, "init.c", "int init;\n")
+	mustWriteSource(t, root, "include/linux/compiler_types.h", `
+#include "private/generated.inc"
+#include <kbuild.inc>
+`)
+	mustWriteSource(t, root, "include/linux/private/generated.inc", "#ifdef CONFIG_DEBUG\n#endif\n")
+	mustWriteSource(t, root, "private/kbuild.inc", "#ifdef CONFIG_EFI_STUB\n#endif\n")
+
+	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
+		{Name: "base", Flags: map[string]string{"CONFIG_DEBUG": "y", "CONFIG_EFI_STUB": "y"}},
+	}, CompactMetadataOptions{
+		Schema:                          CompactSchemaV012,
+		SourceRoot:                      root,
+		SourceGeneratedIncludesComplete: true,
+	})
+	if err != nil {
+		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+	}
+	variant := variantByTarget(metadata, objectTarget(metadata, configByName(metadata, "base"), "init.o"))
+	wantIncludes := []string{"include/linux/private/generated.inc", "private/kbuild.inc"}
+	if !reflect.DeepEqual(variant.SourceIncludes, wantIncludes) {
+		t.Fatalf("SourceIncludes = %v, want %v", variant.SourceIncludes, wantIncludes)
+	}
+	if !variant.SourceIncludesComplete {
+		t.Fatal("resolved default-preinclude closure was marked incomplete")
+	}
+	if variant.ConfigFragment["CONFIG_DEBUG"] != "y" || variant.ConfigFragment["CONFIG_EFI_STUB"] != "y" {
+		t.Fatalf("ConfigFragment = %v, want default-preinclude CONFIG refs", variant.ConfigFragment)
+	}
+}
+
+func TestCompactFootprintPropagatesIncompleteDefaultPreinclude(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	root := t.TempDir()
+	kb, err := ParseKbuild(strings.NewReader("obj-y += init.o\n"), "Kbuild")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	mustWriteSource(t, root, "init.c", "int init;\n")
+	mustWriteSource(t, root, "include/linux/compiler-version.h", "#include GENERATED_VERSION_HEADER\n")
+
+	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
+		{Name: "base", Flags: map[string]string{"CONFIG_NET": "y"}},
+	}, CompactMetadataOptions{
+		Schema:                          CompactSchemaV012,
+		SourceRoot:                      root,
+		SourceGeneratedIncludesComplete: true,
+	})
+	if err != nil {
+		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+	}
+	variant := variantByTarget(metadata, objectTarget(metadata, configByName(metadata, "base"), "init.o"))
+	if variant.SourceIncludesComplete {
+		t.Fatal("computed include in a default preinclude was marked complete")
+	}
+}
+
+func TestObjectsWithGeneratedCompileSourcesRequireFallback(t *testing.T) {
+	for _, object := range []string{
+		"crypto/example.asn1.o",
+		"arch/x86/kernel/cpu/capflags.o",
+		"drivers/tty/vt/consolemap_deftbl.o",
+	} {
+		if !objectUsesGeneratedCSource(object) {
+			t.Errorf("objectUsesGeneratedCSource(%q) = false, want true", object)
+		}
+	}
+	if objectUsesGeneratedCSource("kernel/fork.o") {
+		t.Fatal("ordinary C object requires generated-source fallback")
 	}
 }
 
@@ -133,7 +671,12 @@ func TestCompactFootprintSplitsOnSourceLevelConfig(t *testing.T) {
 	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
 		{Name: "off", Flags: map[string]string{"CONFIG_NET": "y"}},
 		{Name: "on", Flags: map[string]string{"CONFIG_NET": "y", "CONFIG_DEBUG": "y"}},
-	}, CompactMetadataOptions{Schema: CompactSchemaV012, SourceRoot: root, Srcarch: "x86"})
+	}, CompactMetadataOptions{
+		Schema:                          CompactSchemaV012,
+		SourceRoot:                      root,
+		SourceGeneratedIncludesComplete: true,
+		Srcarch:                         "x86",
+	})
 	if err != nil {
 		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
 	}
@@ -163,7 +706,12 @@ func TestCompactFootprintSharesWhenSourceConfigAgrees(t *testing.T) {
 	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
 		{Name: "a", Flags: map[string]string{"CONFIG_NET": "y"}},
 		{Name: "b", Flags: map[string]string{"CONFIG_NET": "y", "CONFIG_EFI_STUB": "y"}},
-	}, CompactMetadataOptions{Schema: CompactSchemaV012, SourceRoot: root, Srcarch: "x86"})
+	}, CompactMetadataOptions{
+		Schema:                          CompactSchemaV012,
+		SourceRoot:                      root,
+		SourceGeneratedIncludesComplete: true,
+		Srcarch:                         "x86",
+	})
 	if err != nil {
 		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
 	}
@@ -175,6 +723,58 @@ func TestCompactFootprintSharesWhenSourceConfigAgrees(t *testing.T) {
 	}
 	if a != b {
 		t.Fatalf("init.o split on an unreferenced config: a=%q b=%q", a, b)
+	}
+}
+
+func TestCompactComputedIncludeUsesFullConfig(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	kb := mustParseKbuildFixture(t)
+	root := t.TempDir()
+	mustWriteSource(t, root, "init.c", "#include CONFIG_PRIVATE_HEADER\n")
+
+	metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
+		{Name: "off", Flags: map[string]string{"CONFIG_NET": "y"}},
+		{Name: "on", Flags: map[string]string{"CONFIG_NET": "y", "CONFIG_DEBUG": "y"}},
+	}, CompactMetadataOptions{Schema: CompactSchemaV012, SourceRoot: root, Srcarch: "x86"})
+	if err != nil {
+		t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+	}
+
+	off := objectTarget(metadata, configByName(metadata, "off"), "init.o")
+	on := objectTarget(metadata, configByName(metadata, "on"), "init.o")
+	if off == "" || on == "" {
+		t.Fatalf("missing init.o target: off=%q on=%q", off, on)
+	}
+	if off == on {
+		t.Fatalf("computed-include init.o shared across distinct configs: both = %q", off)
+	}
+	if got := variantByTarget(metadata, on).ConfigFragment["CONFIG_DEBUG"]; got != "y" {
+		t.Fatalf("init.o (on) fragment CONFIG_DEBUG = %q, want y", got)
+	}
+}
+
+func TestCompactComputedIncludeDoesNotChangeLegacyVariant(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	kb := mustParseKbuildFixture(t)
+	var targets []string
+	for _, source := range []string{"int init;\n", "#include CONFIG_PRIVATE_HEADER\n"} {
+		root := t.TempDir()
+		mustWriteSource(t, root, "init.c", source)
+		metadata, err := tree.CompactMetadataWithOptions(kb, []NamedConfig{
+			{Name: "base", Flags: map[string]string{"CONFIG_NET": "y"}},
+		}, CompactMetadataOptions{Schema: CompactSchemaV011, SourceRoot: root, Srcarch: "x86"})
+		if err != nil {
+			t.Fatalf("CompactMetadataWithOptions() failed: %v", err)
+		}
+		target := objectTarget(metadata, configByName(metadata, "base"), "init.o")
+		variant := variantByTarget(metadata, target)
+		if variant.SourceIncludesComplete {
+			t.Fatal("legacy object variant carries a source-include completeness marker")
+		}
+		targets = append(targets, target)
+	}
+	if targets[0] != targets[1] {
+		t.Fatalf("legacy object target changed for computed include: %q != %q", targets[0], targets[1])
 	}
 }
 

--- a/tests/compact/BUILD.bazel
+++ b/tests/compact/BUILD.bazel
@@ -30,6 +30,7 @@ linux_compact_buildfiles(
     out_metadata = "expected.metadata.golden",
     root = "Kconfig",
     source_config = "//tests/compact:source_config",
+    source_generated_includes_complete = True,
     source_label_package = "//tests/compact",
     source_root_label = "//tests/compact:Kconfig",
 )

--- a/tests/compact/expected.metadata.golden
+++ b/tests/compact/expected.metadata.golden
@@ -48,6 +48,7 @@
       "target": "debug__2b9e2dc7323c658c",
       "object": "debug.o",
       "source": "debug.c",
+      "source_includes_complete": true,
       "mode": "y",
       "flags": ["-Wall"],
       "config_fragment": {
@@ -107,6 +108,7 @@
       "package": "drivers",
       "object": "drivers/foo.o",
       "source": "drivers/foo.c",
+      "source_includes_complete": true,
       "mode": "y",
       "flags": ["-Wall", "-DNET=y"],
       "config_fragment": {
@@ -165,6 +167,7 @@
       "target": "init__3f9f641f5763d521",
       "object": "init.o",
       "source": "init.c",
+      "source_includes_complete": true,
       "mode": "y",
       "flags": ["-Wall"],
       "config_fragment": {
@@ -222,6 +225,7 @@
       "target": "init__da4397a1c4ecd44a",
       "object": "init.o",
       "source": "init.c",
+      "source_includes_complete": true,
       "mode": "y",
       "flags": ["-Wall", "-DNET=y"],
       "config_fragment": {
@@ -280,6 +284,7 @@
       "package": "net",
       "object": "net/core.o",
       "source": "net/core.c",
+      "source_includes_complete": true,
       "mode": "y",
       "flags": ["-Wall", "-DNET=y", "-DNET_CORE"],
       "config_fragment": {


### PR DESCRIPTION
## Summary

- emit each compact Linux object’s recursive source-tree input closure
- accept an exact generated-include manifest, including source backings for generated asm-generic wrappers
- mark closure completeness positively and fall back to the exhaustive source tree whenever parsing or include-search modeling is incomplete
- cover forced includes, implicit compiler preincludes, generated C, multi-source objects, assembler `.incbin`, comments, and preprocessor line splices
- document the `v0.0.15` kconfig release behavior

## Why

Linux object actions currently retain broad source inputs because the compact generator cannot prove their private source dependency closure. That makes otherwise independent actions share a very large input set and caused the two-architecture Aya CI build to run out of memory during analysis.

The positive completeness marker keeps this fail closed: consumers may narrow an action only when the repository rule supplied the complete generated-header namespace and the scanner modeled every source include path. All other producers and uncertain objects retain the exhaustive `all_files` fallback.

This PR prepares the generator release only. After merge, publish all six `v0.0.15` kconfig archives with `VERSION=v0.0.15 ./release_kconfig.sh`; the consumer PR will then pin those immutable artifacts.

## Validation

- `go test ./internal/kconfig ./internal/rusttoolchain ./internal/cmd/kconfig ./internal/cmd/kconfig_parse`
- `go test -race -count=1 ./internal/kconfig ./internal/cmd/kconfig_parse`
- `bazel test //internal/kconfig:kconfig_test //internal/cmd/kconfig:kconfig_test //internal/cmd/kconfig_parse:kconfig_parse_test`
- full unchanged Aya integration command for `vm_aarch64` and `vm_x86_64`: both passed after building and booting the kernels ([BuildBuddy invocation](https://app.buildbuddy.io/invocation/db688161-134b-4e91-a08b-d152bc7d43b4))
- `gofmt -d` and `git diff --check`