### PR TITLE
Host kconfig v0.0.20 release upstream

### DIFF
--- a/aya_e2e/MODULE.bazel.lock
+++ b/aya_e2e/MODULE.bazel.lock
@@ -294,7 +294,7 @@
     },
     "@@linux.bzl+//:extensions.bzl%linux_images": {
       "general": {
-        "bzlTransitiveDigest": "nx819CsZT6DDzD/XMi/RdecUxhGBZ5QkPRIsP/TpzY4=",
+        "bzlTransitiveDigest": "uavzYvzMompVjfsWqcLsEAXWUQgugbXy+6YO+fXYBkA=",
         "usagesDigest": "p6VHWgr+rKdEcDiu5ssG/Jdd/e/tM3ukNrv9zsJ2ua4=",
         "recordedInputs": [
           "REPO_MAPPING:,aya aya+",

--- a/e2e/MODULE.bazel.lock
+++ b/e2e/MODULE.bazel.lock
@@ -293,7 +293,7 @@
     },
     "@@linux.bzl+//:extensions.bzl%linux_images": {
       "general": {
-        "bzlTransitiveDigest": "nx819CsZT6DDzD/XMi/RdecUxhGBZ5QkPRIsP/TpzY4=",
+        "bzlTransitiveDigest": "uavzYvzMompVjfsWqcLsEAXWUQgugbXy+6YO+fXYBkA=",
         "usagesDigest": "IIcEQVbq6PKLoo6IBe7juO0Bt+UflfLvfk61Vz/4qV0=",
         "recordedInputs": [
           "REPO_MAPPING:,e2e_linux_6_12_96 +linux_source_repository+e2e_linux_6_12_96",

--- a/examples/MODULE.bazel.lock
+++ b/examples/MODULE.bazel.lock
@@ -288,7 +288,7 @@
     },
     "@@linux.bzl+//:extensions.bzl%linux_images": {
       "general": {
-        "bzlTransitiveDigest": "nx819CsZT6DDzD/XMi/RdecUxhGBZ5QkPRIsP/TpzY4=",
+        "bzlTransitiveDigest": "uavzYvzMompVjfsWqcLsEAXWUQgugbXy+6YO+fXYBkA=",
         "usagesDigest": "e+vMswoLMFhZTZBOPj/u6dxDllDqKp7btmBZJfnFwew=",
         "recordedInputs": [
           "REPO_MAPPING:,linux_6_18_39 +linux_source_repository+linux_6_18_39",

--- a/internal/kconfig_tool_releases.bzl
+++ b/internal/kconfig_tool_releases.bzl
@@ -7,7 +7,7 @@ visibility("//...")
 
 KCONFIG_TOOL_VERSION = "v0.0.20"
 
-_RELEASE_BASE_URL = "https://github.com/fionera/linux.bzl/releases/download/kconfig-{version}".format(
+_RELEASE_BASE_URL = "https://github.com/hermeticbuild/linux.bzl/releases/download/kconfig-{version}".format(
     version = KCONFIG_TOOL_VERSION,
 )
 


### PR DESCRIPTION
## Summary
- host the `kconfig-v0.0.20` prebuilt downloads under `hermeticbuild/linux.bzl`
- refresh downstream module-extension lock digests for the URL change

## Validation
- verified the upstream tag targets current `main`
- downloaded all six archives and passed the published `SHA256SUMS`
- confirmed all archive digests still match the checked-in integrity pins
- `bazel mod deps --lockfile_mode=error` in the root, `examples`, `e2e`, and `aya_e2e` modules
- `bazel test //... --test_output=errors`
- `bazel test //internal/tests:path_mapping_test --config=path-mapping --test_output=errors`
