### PR TITLE
kconfig: stop clamping resolved values by dir_dep

### DIFF
--- a/internal/kconfig/config.go
+++ b/internal/kconfig/config.go
@@ -171,7 +171,15 @@ func (t *Tree) ResolveConfigWithOptions(name string, raw map[string]string, opts
 				continue
 			}
 			deps := resolver.evalDepExprDefault(sym.DirDep, triY)
-			rawAllowed := minResolvedTri(resolver.baseTri(sym), deps)
+			// scripts/kconfig/symbol.c:sym_calc_value() clamps the user
+			// value and the default by prop->visible.tri (the prompt/
+			// default condition), NOT by sym->dir_dep.tri. dir_dep is the
+			// OR of every definition's inherited menu dependency, so a
+			// symbol defined twice -- once in a dead "if" block, once
+			// unconditionally -- carries the dead block's condition in
+			// dir_dep. ANDing it here disables the symbol even though its
+			// live definition applies. dir_dep only bounds "implied".
+			rawAllowed := resolver.baseTri(sym)
 			impliedAllowed := triN
 			if !resolver.visibleUserValue(sym) {
 				impliedAllowed = minResolvedTri(resolver.evalDepExprDefault(sym.Implied, triN), deps)

--- a/internal/kconfig/config_test.go
+++ b/internal/kconfig/config_test.go
@@ -203,6 +203,107 @@ config TARGET
 	})
 }
 
+// A symbol may be defined in several places. dir_dep is the OR of every
+// definition's inherited menu dependency (see finalizeMenu), so a symbol with
+// one definition inside a dead "if" block and another that applies carries the
+// dead block's condition in dir_dep. scripts/kconfig/symbol.c:sym_calc_value()
+// gates the user value and the default on the prompt/default condition, and
+// uses dir_dep only to bound "imply", so the live definition still wins.
+//
+// arch/Kconfig defines CPU_MITIGATIONS inside "if
+// !ARCH_CONFIGURES_CPU_MITIGATIONS" while arch/x86/Kconfig defines it as a
+// plain "menuconfig ... default y"; x86 selects ARCH_CONFIGURES_CPU_MITIGATIONS,
+// so clamping by dir_dep disabled CPU_MITIGATIONS and every MITIGATION_* symbol
+// guarded by it.
+func TestResolveConfigRedefinedSymbolIgnoresDeadDefinitionDependency(t *testing.T) {
+	fixture := `
+mainmenu "Test"
+
+config ARCH_CONFIGURES_IT
+	bool
+
+config ARCH
+	bool "Arch"
+	default y
+	select ARCH_CONFIGURES_IT
+
+if !ARCH_CONFIGURES_IT
+
+config FEATURE
+	def_bool y
+
+endif
+
+config FEATURE
+	bool "Feature"
+	default y
+
+if FEATURE
+
+config FEATURE_CHILD
+	bool "Child"
+	default y
+
+endif
+`
+
+	t.Run("default", func(t *testing.T) {
+		resolved := mustResolveConfig(t, fixture, map[string]string{})
+		wantConfigValues(t, resolved, map[string]string{
+			"CONFIG_ARCH_CONFIGURES_IT": "y",
+			"CONFIG_FEATURE":            "y",
+			"CONFIG_FEATURE_CHILD":      "y",
+		})
+	})
+
+	t.Run("explicit user value", func(t *testing.T) {
+		resolved := mustResolveConfig(t, fixture, map[string]string{
+			"CONFIG_FEATURE": "y",
+		})
+		wantConfigValues(t, resolved, map[string]string{
+			"CONFIG_FEATURE":       "y",
+			"CONFIG_FEATURE_CHILD": "y",
+		})
+	})
+
+	t.Run("explicit user n still wins", func(t *testing.T) {
+		resolved := mustResolveConfig(t, fixture, map[string]string{
+			"CONFIG_FEATURE": "n",
+		})
+		wantConfigValues(t, resolved, map[string]string{
+			"CONFIG_FEATURE":       "n",
+			"CONFIG_FEATURE_CHILD": "n",
+		})
+	})
+}
+
+// The counterpart to the above: a symbol whose only definition sits in a dead
+// "if" block has no live definition, so it must stay disabled even when the
+// imported config asks for it.
+func TestResolveConfigSoleDefinitionInDeadIfStaysDisabled(t *testing.T) {
+	resolved := mustResolveConfig(t, `
+mainmenu "Test"
+
+config GATE
+	bool "Gate"
+
+if GATE
+
+config TARGET
+	bool "Target"
+	default y
+
+endif
+`, map[string]string{
+		"CONFIG_TARGET": "y",
+	})
+
+	wantConfigValues(t, resolved, map[string]string{
+		"CONFIG_GATE":   "n",
+		"CONFIG_TARGET": "n",
+	})
+}
+
 func TestResolveConfigRawValueConstrainedByTargetDepends(t *testing.T) {
 	resolved := mustResolveConfig(t, `
 mainmenu "Test"


### PR DESCRIPTION
A symbol can be defined in more than one place, and dir_dep is the OR of every definition's inherited menu dependency (finalizeMenu, mirroring scripts/kconfig/menu.c:454). A symbol with one definition inside a dead "if" block therefore carries that dead block's condition in dir_dep even when another definition applies.

scripts/kconfig/symbol.c:sym_calc_value() gates the user value and the default on sym->visible / prop->visible.tri and applies dir_dep only to bound the "imply" contribution. We ANDed dir_dep into the user value and default as well, so a dead definition disabled the symbol outright.

arch/Kconfig defines CPU_MITIGATIONS inside
"if !ARCH_CONFIGURES_CPU_MITIGATIONS" while arch/x86/Kconfig defines it as "menuconfig CPU_MITIGATIONS ... default y". x86 selects ARCH_CONFIGURES_CPU_MITIGATIONS, so dir_dep evaluated to n, forcing CPU_MITIGATIONS off and closing the "if CPU_MITIGATIONS" block that guards the MITIGATION_* symbols. Every x86 config resolved with all CPU speculation mitigations disabled -- silently, including when the imported .config set them to y -- and additionally enabled the X86_DISABLED_FEATURE_* symbols that compile the corresponding feature checks out of cpufeaturemasks.h.

Drop the clamp. The per-definition condition is still enforced, because baseTri/defaultTri/promptVisibility clamp by prop.Visible, which already has menu.Dep folded in; the condition now comes from the live definition instead of the OR across all of them. Imply keeps its dir_dep bound.

Measured against upstream scripts/kconfig/conf --olddefconfig on the same tree with the same pinned toolchain: examples/configs/x86_64.config goes from 29 symbols missing and 6 spurious to exact agreement, and Firecracker's microvm-kernel-ci-x86_64-6.18.config from 27 missing to 2 (both remaining ones are compiler-probe symbols, unrelated to this path). The x86_64 object graph gains arch/x86/lib/retpoline.o, arch/x86/mm/pti.o, arch/x86/kernel/callthunks.o and mm/execmem.o.