### PR TITLE
Prepare linux.bzl v0.0.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "linux.bzl",
-    version = "0.1.0",
+    version = "0.0.1",
 )
 
 bazel_dep(name = "bazel_lib", version = "3.2.2")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ execution, and reusable action-cache entries.
 Add `linux.bzl` and a hermetic C/C++ toolchain to `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "linux.bzl", version = "0.1.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "llvm", version = "0.8.14")
 
 register_toolchains(
@@ -51,8 +51,7 @@ linux_images.image(
 use_repo(linux_images, "example_kernel")
 ```
 
-The `bazel_dep` coordinates apply once `0.1.0` is published. When developing
-against a checkout, add:
+When developing against a checkout, add:
 
 ```starlark
 local_path_override(

--- a/aya_e2e/MODULE.bazel
+++ b/aya_e2e/MODULE.bazel
@@ -4,7 +4,7 @@ module(
 )
 
 bazel_dep(name = "aya", version = "0.0.0")
-bazel_dep(name = "linux.bzl", version = "0.1.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "llvm", version = "0.8.14")
 bazel_dep(name = "rules_rs", version = "0.0.98")
 

--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 
 bazel_dep(name = "bazel_lib", version = "3.2.2")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-bazel_dep(name = "linux.bzl", version = "0.1.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "llvm", version = "0.8.14", repo_name = "hermetic_llvm")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_go", version = "0.62.0")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "linux.bzl", version = "0.1.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "llvm", version = "0.8.14")
 
 # This override makes the example exercise the adjacent checkout. Remove it

--- a/internal/tests/linux_image_extension_integration/fixture/linux_bzl/MODULE.bazel
+++ b/internal/tests/linux_image_extension_integration/fixture/linux_bzl/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "linux.bzl",
-    version = "0.1.0",
+    version = "0.0.1",
 )
 
 bazel_dep(name = "llvm", version = "0.8.14")

--- a/internal/tests/linux_image_extension_integration/fixture/non_root_tags/MODULE.bazel
+++ b/internal/tests/linux_image_extension_integration/fixture/non_root_tags/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "1.0.0",
 )
 
-bazel_dep(name = "linux.bzl", version = "0.1.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "linux_image_tagging_dependency", version = "1.0.0")
 bazel_dep(name = "llvm", version = "0.8.14")
 

--- a/internal/tests/linux_image_extension_integration/fixture/non_root_tags/dependency/MODULE.bazel
+++ b/internal/tests/linux_image_extension_integration/fixture/non_root_tags/dependency/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "1.0.0",
 )
 
-bazel_dep(name = "linux.bzl", version = "0.1.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "llvm", version = "0.8.14")
 
 linux_images = use_extension("@linux.bzl//:extensions.bzl", "linux_images")

--- a/internal/tests/linux_image_extension_integration/fixture/removed_attr/MODULE.bazel
+++ b/internal/tests/linux_image_extension_integration/fixture/removed_attr/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "1.0.0",
 )
 
-bazel_dep(name = "linux.bzl", version = "0.1.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "llvm", version = "0.8.14")
 
 local_path_override(

--- a/internal/tests/linux_image_extension_integration/fixture/repository_name_collision/MODULE.bazel
+++ b/internal/tests/linux_image_extension_integration/fixture/repository_name_collision/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "1.0.0",
 )
 
-bazel_dep(name = "linux.bzl", version = "0.1.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "llvm", version = "0.8.14")
 
 local_path_override(

--- a/internal/tests/linux_image_extension_integration/fixture/success/MODULE.bazel
+++ b/internal/tests/linux_image_extension_integration/fixture/success/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "1.0.0",
 )
 
-bazel_dep(name = "linux.bzl", version = "0.1.0")
+bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "llvm", version = "0.8.14")
 
 local_path_override(


### PR DESCRIPTION
## Summary

- declare `linux.bzl` as version `0.0.1`
- update all in-repository consumers and integration fixtures to the release version
- make the README quick start describe the published coordinates

## Validation

- `USE_BAZEL_VERSION=9.1.0 bazel test //... --lockfile_mode=error` (145 tests)
- `bazel mod deps --lockfile_mode=error` in `examples`, `e2e`, and `aya_e2e`

After this merges and the `main` CI completes, the merge commit will be tagged `v0.0.1` and published with a deterministic source archive.