### PR TITLE
Automate releases and BCR publishing

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -1,0 +1,9 @@
+# Bazel Central Registry
+
+When the ruleset is released, it is published to the Bazel Central Registry
+automatically:
+<https://registry.bazel.build>
+
+This folder contains configuration files for the publish step. See
+<https://github.com/bazel-contrib/publish-to-bcr/blob/main/templates/README.md>
+for the authoritative documentation about these files.

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,14 @@
+{
+  "homepage": "https://github.com/hermeticbuild/linux.bzl",
+  "maintainers": [
+    {
+      "name": "Tim Windelschmidt",
+      "email": "fionera@fionera.de",
+      "github_user_id": 5741401,
+      "github": "fionera"
+    }
+  ],
+  "repository": ["github:hermeticbuild/linux.bzl"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,13 @@
+bcr_test_module:
+  module_path: examples
+  matrix:
+    platform: [ubuntu2404]
+    bazel: [9.x]
+  tasks:
+    smoke_test:
+      name: Build initramfs and x86_64 kernel
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - //:example_initramfs
+        - //:x86_64_kernel

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "**leave this alone**",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,33 @@
+# Publish new releases to Bazel Central Registry.
+name: Publish to BCR
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      publish_token:
+        required: false
+      BCR_PUBLISH_TOKEN:
+        required: false
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Git tag being released
+        required: true
+        type: string
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      registry_fork: fionera/bazel-central-registry
+      draft: false
+      attest: true
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+# Cut a release whenever a new tag is pushed to the repository.
+name: Release
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      publish_token:
+        required: false
+      BCR_PUBLISH_TOKEN:
+        required: false
+  push:
+    tags:
+      - "v*.*.*"
+permissions:
+  id-token: write
+  attestations: write
+  contents: write
+jobs:
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
+    with:
+      release_files: linux.bzl-*.tar.gz
+      prerelease: false
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+    secrets:
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+TAG=$1
+PREFIX="linux.bzl-${TAG:1}"
+ARCHIVE="linux.bzl-$TAG.tar.gz"
+
+git archive --format=tar --prefix="${PREFIX}/" "${TAG}" | gzip > "${ARCHIVE}"
+
+cat << EOF
+## Add to your \`MODULE.bazel\` file:
+
+\`\`\`starlark
+bazel_dep(name = "linux.bzl", version = "${TAG:1}")
+\`\`\`
+
+EOF

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -48,9 +48,10 @@ VERSION=vX.Y.Z ./release_kconfig.sh
 
 ## Publish
 
-1. Tag the verified release commit as `vX.Y.Z`.
-2. Publish the module source archive and verify it against the release
-   integrity.
+1. Tag the verified release commit as `vX.Y.Z` and push the tag. The release
+   workflow creates the module source archive and starts the BCR publishing
+   workflow using the configuration under `.bcr/`.
+2. Verify the release archive and the generated BCR pull request.
 3. Test a clean consumer module using the tag, without `local_path_override` or
    a locally built generator.
 


### PR DESCRIPTION
## Summary

- add `publish-to-bcr` templates adapted from `rules_rs`
- create and attest release archives from pushed semantic-version tags
- publish releases through the writable `fionera/bazel-central-registry` fork
- run the BCR consumer smoke test against the initramfs and x86_64 kernel examples
- document the automated release flow

## Why

The first `linux.bzl` release was assembled and submitted to BCR manually. Keeping the archive layout, integrity generation, registry metadata, and pull-request creation in a tag-driven workflow makes subsequent releases repeatable and reviewable.

The BCR presubmit intentionally uses Bazel 9. The full x86_64 kernel target currently fails under Bazel 8 while compiling Linux's host-side objtool because of an unrelated host-header incompatibility; the repository's normal CI continues to run its root test suite under both Bazel 8 and Bazel 9.

Publishing requires the `BCR_PUBLISH_TOKEN` Actions secret to contain a classic PAT that can push to `fionera/bazel-central-registry` and open a PR against the public registry.

## Validation

- `actionlint .github/workflows/*.yml .github/workflows/*.yaml`
- `bash -n .github/workflows/release_prep.sh`
- `jq empty .bcr/metadata.template.json .bcr/source.template.json`
- `git diff --check`
