### PR TITLE
Make LLVM and Buildifier development-only

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,9 @@ module(
 
 bazel_dep(name = "bazel_lib", version = "3.2.2")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.1")
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.1", dev_dependency = True)
+
 bazel_dep(name = "elfutils", version = "0.195")
 bazel_dep(name = "gazelle", version = "0.51.3")
 bazel_dep(name = "libbpf", version = "1.7.0")
@@ -43,44 +45,25 @@ use_repo(bindgen_toolchains, "rules_rust_bindgen")
 tar_toolchains = use_extension("@tar.bzl//tar:extensions.bzl", "toolchains", dev_dependency = True)
 use_repo(tar_toolchains, "bsd_tar_toolchains")
 
-llvm_toolchains = use_extension("@llvm//extensions:toolchain.bzl", "toolchain")
-llvm_toolchains.target(
-    arch = "x86_64",
-    os = "linux",
-)
-llvm_toolchains.target(
-    arch = "aarch64",
-    os = "linux",
-)
-use_repo(llvm_toolchains, "llvm_toolchains")
-
-register_toolchains(
-    "@default_rust_toolchains//:all",
-    dev_dependency = True,
-)
-
 register_toolchains(
     "@rules_rust_bindgen//:linux_amd64",
 )
 
 register_toolchains(
+    "@default_rust_toolchains//:all",
     "@bsd_tar_toolchains//:all",
-    dev_dependency = True,
-)
-
-register_toolchains(
-    "@llvm_toolchains//:linux_aarch64_to_linux_aarch64",
-    "@llvm_toolchains//:linux_aarch64_to_linux_x86_64",
-    "@llvm_toolchains//:linux_x86_64_to_linux_aarch64",
-    "@llvm_toolchains//:linux_x86_64_to_linux_x86_64",
-    "@llvm_toolchains//:macos_aarch64_to_linux_aarch64",
-    "@llvm_toolchains//:macos_aarch64_to_linux_x86_64",
-    "@llvm_toolchains//:macos_x86_64_to_linux_aarch64",
-    "@llvm_toolchains//:macos_x86_64_to_linux_x86_64",
-    "@llvm_toolchains//:windows_aarch64_to_linux_aarch64",
-    "@llvm_toolchains//:windows_aarch64_to_linux_x86_64",
-    "@llvm_toolchains//:windows_x86_64_to_linux_aarch64",
-    "@llvm_toolchains//:windows_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:linux_aarch64_to_linux_aarch64",
+    "@llvm//toolchain:linux_aarch64_to_linux_x86_64",
+    "@llvm//toolchain:linux_x86_64_to_linux_aarch64",
+    "@llvm//toolchain:linux_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:macos_aarch64_to_linux_aarch64",
+    "@llvm//toolchain:macos_aarch64_to_linux_x86_64",
+    "@llvm//toolchain:macos_x86_64_to_linux_aarch64",
+    "@llvm//toolchain:macos_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:windows_aarch64_to_linux_aarch64",
+    "@llvm//toolchain:windows_aarch64_to_linux_x86_64",
+    "@llvm//toolchain:windows_x86_64_to_linux_aarch64",
+    "@llvm//toolchain:windows_x86_64_to_linux_x86_64",
     dev_dependency = True,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,11 +7,11 @@ bazel_dep(name = "bazel_lib", version = "3.2.2")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.1", dev_dependency = True)
+bazel_dep(name = "llvm", version = "0.8.14", dev_dependency = True)
 
 bazel_dep(name = "elfutils", version = "0.195")
 bazel_dep(name = "gazelle", version = "0.51.3")
 bazel_dep(name = "libbpf", version = "1.7.0")
-bazel_dep(name = "llvm", version = "0.8.14")
 bazel_dep(name = "lz4", version = "1.10.0.bcr.1")
 bazel_dep(name = "pahole", version = "1.31")
 bazel_dep(name = "platforms", version = "1.0.0")
@@ -52,18 +52,7 @@ register_toolchains(
 register_toolchains(
     "@default_rust_toolchains//:all",
     "@bsd_tar_toolchains//:all",
-    "@llvm//toolchain:linux_aarch64_to_linux_aarch64",
-    "@llvm//toolchain:linux_aarch64_to_linux_x86_64",
-    "@llvm//toolchain:linux_x86_64_to_linux_aarch64",
-    "@llvm//toolchain:linux_x86_64_to_linux_x86_64",
-    "@llvm//toolchain:macos_aarch64_to_linux_aarch64",
-    "@llvm//toolchain:macos_aarch64_to_linux_x86_64",
-    "@llvm//toolchain:macos_x86_64_to_linux_aarch64",
-    "@llvm//toolchain:macos_x86_64_to_linux_x86_64",
-    "@llvm//toolchain:windows_aarch64_to_linux_aarch64",
-    "@llvm//toolchain:windows_aarch64_to_linux_x86_64",
-    "@llvm//toolchain:windows_x86_64_to_linux_aarch64",
-    "@llvm//toolchain:windows_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:all",
     dev_dependency = True,
 )
 

--- a/README.md
+++ b/README.md
@@ -17,18 +17,7 @@ bazel_dep(name = "linux.bzl", version = "0.0.1")
 bazel_dep(name = "llvm", version = "0.8.14")
 
 register_toolchains(
-    "@llvm//toolchain:linux_aarch64_to_linux_aarch64",
-    "@llvm//toolchain:linux_aarch64_to_linux_x86_64",
-    "@llvm//toolchain:linux_x86_64_to_linux_aarch64",
-    "@llvm//toolchain:linux_x86_64_to_linux_x86_64",
-    "@llvm//toolchain:macos_aarch64_to_linux_aarch64",
-    "@llvm//toolchain:macos_aarch64_to_linux_x86_64",
-    "@llvm//toolchain:macos_x86_64_to_linux_aarch64",
-    "@llvm//toolchain:macos_x86_64_to_linux_x86_64",
-    "@llvm//toolchain:windows_aarch64_to_linux_aarch64",
-    "@llvm//toolchain:windows_aarch64_to_linux_x86_64",
-    "@llvm//toolchain:windows_x86_64_to_linux_aarch64",
-    "@llvm//toolchain:windows_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:all",
 )
 
 linux_source_repository = use_repo_rule(
@@ -150,11 +139,13 @@ surface:
 
 There is intentionally no `arch` attribute. Architecture is derived from the
 base config, while the platform must carry the matching x86_64 or aarch64 CPU
-constraint and select a matching Clang toolchain. It does not have to come from
-a particular module or use a prescribed label. There are also no graph
-profiles, explicit Kbuild linker labels, compiler paths, host probe overrides,
-image-format switches, or signing keys in the public API. Import each declared
-facade repository explicitly with `use_repo`.
+constraint and select a matching LLVM/Clang toolchain. The toolchain must expose
+`llvm-nm` and `llvm-objcopy` through `CcToolchainInfo.all_files`; the supported
+setup is the `llvm` module shown above. Repository and platform labels may be
+renamed. There are also no graph profiles, explicit Kbuild linker labels,
+compiler paths, host probe overrides, image-format switches, or signing keys in
+the public API. Import each declared facade repository explicitly with
+`use_repo`.
 
 ### Initramfs
 
@@ -466,12 +457,13 @@ system_map
 ## Toolchains and hermeticity
 
 `platform` is mandatory on every `linux_images.image` tag. It must carry a
-Linux x86_64 or aarch64 CPU constraint and select a matching Clang toolchain.
-The extension applies it once at the public `:kernel` gateway. Analysis rejects
-non-Clang compilers and target platforms that disagree with the config; it does
-not require a particular platform label, module repository, or exact Clang
-version. Kconfig and Kbuild capability decisions remain fixed to LLVM 22.1.8,
-so selecting a newer Clang asserts compatibility with those decisions.
+Linux x86_64 or aarch64 CPU constraint and select a matching LLVM/Clang
+toolchain. The extension applies it once at the public `:kernel` gateway.
+Analysis rejects non-Clang compilers, target platforms that disagree with the
+config, and toolchains that do not expose `llvm-nm` and `llvm-objcopy` through
+`CcToolchainInfo.all_files`. The supported toolchain is provided by `llvm`
+0.8.14 and uses LLVM 22.1.8. Repository and platform labels may be renamed, but
+using another LLVM packaging or version is outside the supported contract.
 
 Repository generation downloads the platform-specific, integrity-pinned
 Kconfig graph generator selected by the rules release's checked-in table. The

--- a/aya_e2e/MODULE.bazel.lock
+++ b/aya_e2e/MODULE.bazel.lock
@@ -70,8 +70,6 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1.1/MODULE.bazel": "2e2e306add04b7c7cd21e73c9293dcbd7528a08a84338e919036f402eb6b1e2e",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1.1/source.json": "4c86fd3a384a09613c2213fb1f71562d6d70471977e6e81173e6625fd6ce53bc",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
     "https://bcr.bazel.build/modules/bzip2/1.0.8.bcr.3/MODULE.bazel": "29ecf4babfd3c762be00d7573c288c083672ab60e79c833ff7f49ee662e54471",

--- a/e2e/MODULE.bazel
+++ b/e2e/MODULE.bazel
@@ -13,18 +13,7 @@ bazel_dep(name = "rules_qemu", version = "0.3.0")
 bazel_dep(name = "rules_rs", version = "0.0.98")
 
 register_toolchains(
-    "@hermetic_llvm//toolchain:linux_aarch64_to_linux_aarch64",
-    "@hermetic_llvm//toolchain:linux_aarch64_to_linux_x86_64",
-    "@hermetic_llvm//toolchain:linux_x86_64_to_linux_aarch64",
-    "@hermetic_llvm//toolchain:linux_x86_64_to_linux_x86_64",
-    "@hermetic_llvm//toolchain:macos_aarch64_to_linux_aarch64",
-    "@hermetic_llvm//toolchain:macos_aarch64_to_linux_x86_64",
-    "@hermetic_llvm//toolchain:macos_x86_64_to_linux_aarch64",
-    "@hermetic_llvm//toolchain:macos_x86_64_to_linux_x86_64",
-    "@hermetic_llvm//toolchain:windows_aarch64_to_linux_aarch64",
-    "@hermetic_llvm//toolchain:windows_aarch64_to_linux_x86_64",
-    "@hermetic_llvm//toolchain:windows_x86_64_to_linux_aarch64",
-    "@hermetic_llvm//toolchain:windows_x86_64_to_linux_x86_64",
+    "@hermetic_llvm//toolchain:all",
 )
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")

--- a/e2e/MODULE.bazel.lock
+++ b/e2e/MODULE.bazel.lock
@@ -70,8 +70,6 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1.1/MODULE.bazel": "2e2e306add04b7c7cd21e73c9293dcbd7528a08a84338e919036f402eb6b1e2e",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1.1/source.json": "4c86fd3a384a09613c2213fb1f71562d6d70471977e6e81173e6625fd6ce53bc",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
     "https://bcr.bazel.build/modules/bzip2/1.0.8.bcr.3/MODULE.bazel": "29ecf4babfd3c762be00d7573c288c083672ab60e79c833ff7f49ee662e54471",

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -13,22 +13,8 @@ local_path_override(
     path = "..",
 )
 
-# Register only the host/target pairs used by linux.bzl. The catch-all target
-# also registers every bootstrap stage and unrelated OS/CPU combination, which
-# makes Bazel analyze hundreds of toolchains before reaching the kernel graph.
 register_toolchains(
-    "@llvm//toolchain:linux_aarch64_to_linux_aarch64",
-    "@llvm//toolchain:linux_aarch64_to_linux_x86_64",
-    "@llvm//toolchain:linux_x86_64_to_linux_aarch64",
-    "@llvm//toolchain:linux_x86_64_to_linux_x86_64",
-    "@llvm//toolchain:macos_aarch64_to_linux_aarch64",
-    "@llvm//toolchain:macos_aarch64_to_linux_x86_64",
-    "@llvm//toolchain:macos_x86_64_to_linux_aarch64",
-    "@llvm//toolchain:macos_x86_64_to_linux_x86_64",
-    "@llvm//toolchain:windows_aarch64_to_linux_aarch64",
-    "@llvm//toolchain:windows_aarch64_to_linux_x86_64",
-    "@llvm//toolchain:windows_x86_64_to_linux_aarch64",
-    "@llvm//toolchain:windows_x86_64_to_linux_x86_64",
+    "@llvm//toolchain:all",
 )
 
 linux_source_repository = use_repo_rule(

--- a/examples/MODULE.bazel.lock
+++ b/examples/MODULE.bazel.lock
@@ -69,8 +69,6 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1.1/MODULE.bazel": "2e2e306add04b7c7cd21e73c9293dcbd7528a08a84338e919036f402eb6b1e2e",
-    "https://bcr.bazel.build/modules/buildifier_prebuilt/8.2.1.1/source.json": "4c86fd3a384a09613c2213fb1f71562d6d70471977e6e81173e6625fd6ce53bc",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
     "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
     "https://bcr.bazel.build/modules/bzip2/1.0.8.bcr.3/MODULE.bazel": "29ecf4babfd3c762be00d7573c288c083672ab60e79c833ff7f49ee662e54471",

--- a/internal/linux_modules.bzl
+++ b/internal/linux_modules.bzl
@@ -338,7 +338,7 @@ def _btf_module(ctx, config, vmlinux, linked, out, version, tools, external_modu
     pahole_args.add("-input", linked)
     pahole_args.add("-output", encoded)
     pahole_args.add("-env")
-    pahole_args.add(tools.llvm_objcopy.executable, format = "LLVM_OBJCOPY=%s")
+    pahole_args.add(tools.llvm_objcopy, format = "LLVM_OBJCOPY=%s")
     pahole_args.add("--")
     pahole_args.add(tools.pahole.executable)
     pahole_args.add("-J")
@@ -386,8 +386,9 @@ def _empty_file(ctx, path):
     ctx.actions.write(out, "")
     return out
 
-def _builtin_module_metadata(ctx, vmlinux):
+def _builtin_module_metadata(ctx, cc_toolchain, vmlinux):
     raw = ctx.actions.declare_file(ctx.label.name + ".sdk/modules.builtin.modinfo.raw")
+    llvm_objcopy = linux_module_cc_helpers.llvm_objcopy(cc_toolchain)
     objcopy_args = ctx.actions.args()
     objcopy_args.add_all([
         "-j",
@@ -399,7 +400,7 @@ def _builtin_module_metadata(ctx, vmlinux):
     ])
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
+        executable = llvm_objcopy,
         inputs = [vmlinux.vmlinux_unstripped],
         outputs = [raw],
         arguments = [objcopy_args],
@@ -440,11 +441,11 @@ def _linux_module_sdk_impl(ctx):
         target,
     )
 
-    modules_builtin, modules_builtin_modinfo = _builtin_module_metadata(ctx, vmlinux)
+    modules_builtin, modules_builtin_modinfo = _builtin_module_metadata(ctx, target.cc_toolchain, vmlinux)
     ko_files = []
     btf_tools = struct(
         btfmutate = ctx.attr._btfmutate[DefaultInfo].files_to_run,
-        llvm_objcopy = ctx.attr._llvm_objcopy[DefaultInfo].files_to_run,
+        llvm_objcopy = linux_module_cc_helpers.llvm_objcopy(target.cc_toolchain),
         pahole = ctx.attr.pahole[DefaultInfo].files_to_run if ctx.attr.pahole else None,
         resolve_btfids = ctx.attr.resolve_btfids_tool[DefaultInfo].files_to_run if ctx.attr.resolve_btfids_tool else None,
     )
@@ -587,12 +588,6 @@ linux_module_sdk = rule(
         "_builtinmodinfo": attr.label(
             cfg = "exec",
             default = Label("//internal/cmd/builtinmodinfo"),
-            executable = True,
-        ),
-        "_llvm_objcopy": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-objcopy"),
             executable = True,
         ),
     },

--- a/internal/linux_objects.bzl
+++ b/internal/linux_objects.bzl
@@ -280,6 +280,29 @@ def _cc_feature_configuration(ctx, cc_toolchain):
         unsupported_features = ctx.disabled_features,
     )
 
+def _llvm_tool(cc_toolchain, name):
+    basenames = [name, name + ".exe"]
+    matches = [
+        file
+        for file in cc_toolchain.all_files.to_list()
+        if file.basename in basenames
+    ]
+    if len(matches) != 1:
+        fail(
+            "selected C/C++ toolchain must provide exactly one %s (%s), found: %s" % (
+                name,
+                ", ".join(basenames),
+                ", ".join(sorted([file.path for file in matches])) or "none",
+            ),
+        )
+    return matches[0]
+
+def _llvm_nm(cc_toolchain):
+    return _llvm_tool(cc_toolchain, "llvm-nm")
+
+def _llvm_objcopy(cc_toolchain):
+    return _llvm_tool(cc_toolchain, "llvm-objcopy")
+
 def _cc_compile_flags(ctx, cc_toolchain, feature_configuration):
     variables = cc_common.create_compile_variables(
         feature_configuration = feature_configuration,
@@ -1196,17 +1219,18 @@ def _linux_realmode_compile(ctx, compiler, cc_toolchain, config, generated_heade
     )
     return out
 
-def _linux_realmode_pasyms(ctx, objects):
+def _linux_realmode_pasyms(ctx, cc_toolchain, objects):
     out = ctx.actions.declare_file(ctx.label.name + ".obj/arch/x86/realmode/rm/pasyms.h")
+    llvm_nm = _llvm_nm(cc_toolchain)
     args = ctx.actions.args()
-    args.add("-nm", ctx.executable._llvm_nm)
+    args.add("-nm", llvm_nm)
     args.add("-out", out)
     args.add_all(objects)
     path_mapped_run(
         ctx.actions,
         executable = ctx.attr._pasyms[DefaultInfo].files_to_run,
         inputs = objects,
-        tools = [ctx.attr._llvm_nm[DefaultInfo].files_to_run],
+        tools = [llvm_nm],
         outputs = [out],
         arguments = [args],
         mnemonic = "LinuxRealmodePASYMS",
@@ -1312,7 +1336,7 @@ def _linux_realmode_outputs(ctx, compiler, linker, cc_toolchain, config, generat
             out_relpath,
         ))
 
-    pasyms = _linux_realmode_pasyms(ctx, objects)
+    pasyms = _linux_realmode_pasyms(ctx, cc_toolchain, objects)
     linker_script = _linux_realmode_linker_script(ctx, compiler, cc_toolchain, config, generated_headers, source_root, pasyms)
     elf = _linux_realmode_link(ctx, linker, cc_toolchain, objects, linker_script)
 
@@ -1324,8 +1348,8 @@ def _linux_realmode_outputs(ctx, compiler, linker, cc_toolchain, config, generat
     objcopy_args.add(bin)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [elf, ctx.executable._llvm_objcopy],
+        executable = _llvm_objcopy(cc_toolchain),
+        inputs = [elf],
         outputs = [bin],
         arguments = [objcopy_args],
         mnemonic = "LinuxRealmodeObjcopy",
@@ -1501,8 +1525,8 @@ def _linux_vdso_image_source(ctx, compiler, linker, cc_toolchain, feature_config
     objcopy_args.add(stripped)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [dbg, ctx.executable._llvm_objcopy],
+        executable = _llvm_objcopy(cc_toolchain),
+        inputs = [dbg],
         outputs = [stripped],
         arguments = [objcopy_args],
         mnemonic = "LinuxVDSOObjcopy",
@@ -2099,6 +2123,8 @@ def _linux_arm64_vdso_outputs(ctx, cc_toolchain, feature_configuration, config, 
         progress_message = "Linking Linux arm64 vDSO %{label}",
     )
 
+    llvm_nm = _llvm_nm(cc_toolchain)
+    llvm_objcopy = _llvm_objcopy(cc_toolchain)
     so = ctx.actions.declare_file(base + "/arch/arm64/kernel/vdso/vdso.so")
     objcopy_args = ctx.actions.args()
     objcopy_args.add("-S")
@@ -2106,8 +2132,8 @@ def _linux_arm64_vdso_outputs(ctx, cc_toolchain, feature_configuration, config, 
     objcopy_args.add(so)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [dbg, ctx.executable._llvm_objcopy],
+        executable = llvm_objcopy,
+        inputs = [dbg],
         outputs = [so],
         arguments = [objcopy_args],
         mnemonic = "LinuxARM64VDSOObjcopy",
@@ -2117,13 +2143,13 @@ def _linux_arm64_vdso_outputs(ctx, cc_toolchain, feature_configuration, config, 
     nm = ctx.actions.declare_file(base + "/arch/arm64/kernel/vdso/vdso.so.dbg.nm")
     nm_args = ctx.actions.args()
     nm_args.add(nm)
-    nm_args.add(ctx.executable._llvm_nm)
+    nm_args.add(llvm_nm)
     nm_args.add(dbg)
     path_mapped_run(
         ctx.actions,
         executable = ctx.attr._runandwrite[DefaultInfo].files_to_run,
         inputs = [dbg],
-        tools = [ctx.attr._llvm_nm[DefaultInfo].files_to_run],
+        tools = [llvm_nm],
         outputs = [nm],
         arguments = [nm_args],
         mnemonic = "LinuxARM64VDSONM",
@@ -2337,8 +2363,8 @@ def _linux_arm64_vdso32_outputs(ctx, cc_toolchain, feature_configuration, config
     objcopy_args.add(so)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [dbg, ctx.executable._llvm_objcopy],
+        executable = _llvm_objcopy(cc_toolchain),
+        inputs = [dbg],
         outputs = [so],
         arguments = [objcopy_args],
         mnemonic = "LinuxARM64VDSO32Objcopy",
@@ -3306,18 +3332,6 @@ linux_arm64_generated_headers = rule(
         "_arm64headers": attr.label(
             cfg = "exec",
             default = Label("//internal/cmd/arm64headers"),
-            executable = True,
-        ),
-        "_llvm_nm": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-nm"),
-            executable = True,
-        ),
-        "_llvm_objcopy": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-objcopy"),
             executable = True,
         ),
         "_runandwrite": attr.label(
@@ -4459,8 +4473,8 @@ def _linux_object_impl(ctx):
         objcopy_args.add(objcopy_out)
         path_mapped_run(
             ctx.actions,
-            executable = ctx.executable._llvm_objcopy,
-            inputs = [objtool_out, ctx.executable._llvm_objcopy],
+            executable = _llvm_objcopy(cc_toolchain),
+            inputs = [objtool_out],
             outputs = [objcopy_out],
             arguments = [objcopy_args],
             mnemonic = "LinuxObjectObjcopy",
@@ -4634,18 +4648,6 @@ linux_object = rule(
         "_scsidevinfo": attr.label(
             cfg = "exec",
             default = Label("//internal/cmd/scsidevinfo"),
-            executable = True,
-        ),
-        "_llvm_nm": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-nm"),
-            executable = True,
-        ),
-        "_llvm_objcopy": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-objcopy"),
             executable = True,
         ),
         "_pasyms": attr.label(
@@ -4910,8 +4912,8 @@ def _linux_arm64_nvhe_object_impl(ctx):
     objcopy_args.add(out)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [rel, ctx.executable._llvm_objcopy],
+        executable = _llvm_objcopy(cc_toolchain),
+        inputs = [rel],
         outputs = [out],
         arguments = [objcopy_args],
         mnemonic = "LinuxArm64NvheObjcopy",
@@ -4972,12 +4974,6 @@ linux_arm64_nvhe_object = rule(
         "_genhyprel": attr.label(
             cfg = "exec",
             default = Label("//internal/cmd/genhyprel"),
-            executable = True,
-        ),
-        "_llvm_objcopy": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-objcopy"),
             executable = True,
         ),
         "_runandwrite": attr.label(
@@ -5467,17 +5463,18 @@ def _linux_vmlinux_export_object(ctx, compiler, cc_toolchain, feature_configurat
         objtool_mode = "builtin-always" if _linux_vmlinux_export_uses_objtool(config, ctx.attr.version) else "",
     )
 
-def _linux_system_map(ctx, input, name):
+def _linux_system_map(ctx, cc_toolchain, input, name):
     nm_out = ctx.actions.declare_file(ctx.label.name + ".obj/" + name + ".nm")
+    llvm_nm = _llvm_nm(cc_toolchain)
     nm_args = ctx.actions.args()
-    nm_args.add("-nm", ctx.executable._llvm_nm)
+    nm_args.add("-nm", llvm_nm)
     nm_args.add("-in", input)
     nm_args.add("-out", nm_out)
     path_mapped_run(
         ctx.actions,
         executable = ctx.attr._nmrun[DefaultInfo].files_to_run,
         inputs = [input],
-        tools = [ctx.attr._llvm_nm[DefaultInfo].files_to_run],
+        tools = [llvm_nm],
         outputs = [nm_out],
         arguments = [nm_args],
         mnemonic = "LinuxVmlinuxNM",
@@ -5499,16 +5496,16 @@ def _linux_system_map(ctx, input, name):
     )
     return out
 
-def _linux_sorttable(ctx, config, input):
+def _linux_sorttable(ctx, cc_toolchain, config, input):
     out = ctx.actions.declare_file(ctx.label.name + ".sorted.vmlinux")
     nm_out = ctx.actions.declare_file(ctx.label.name + ".obj/.tmp_vmlinux.nm-sort")
-    inputs = [input, config.config]
-    tools = [ctx.attr._llvm_nm[DefaultInfo].files_to_run]
+    llvm_nm = _llvm_nm(cc_toolchain)
+    tools = [llvm_nm]
     if ctx.executable.sorttable_tool:
         tools.append(ctx.attr.sorttable_tool[DefaultInfo].files_to_run)
     args = ctx.actions.args()
     args.add("-config", config.config)
-    args.add("-nm", ctx.executable._llvm_nm)
+    args.add("-nm", llvm_nm)
     if ctx.executable.sorttable_tool:
         args.add("-sorttable")
         args.add(ctx.executable.sorttable_tool)
@@ -5518,7 +5515,7 @@ def _linux_sorttable(ctx, config, input):
     path_mapped_run(
         ctx.actions,
         executable = ctx.attr._sorttablerun[DefaultInfo].files_to_run,
-        inputs = inputs,
+        inputs = [input, config.config],
         tools = tools,
         outputs = [out, nm_out],
         arguments = [args],
@@ -5527,7 +5524,7 @@ def _linux_sorttable(ctx, config, input):
     )
     return out
 
-def _linux_strip_vmlinux(ctx, config, input, out):
+def _linux_strip_vmlinux(ctx, cc_toolchain, config, input, out):
     set_flags = ["--set-section-flags", ".modinfo=noload"]
     remove_flags = [
         "--remove-section=.modinfo",
@@ -5549,6 +5546,7 @@ def _linux_strip_vmlinux(ctx, config, input, out):
             "--remove-section=.rel.*",
         ])
 
+    llvm_objcopy = _llvm_objcopy(cc_toolchain)
     prepared = ctx.actions.declare_file(ctx.label.name + ".obj/vmlinux.strip-prepared")
     prepare_args = ctx.actions.args()
     prepare_args.add_all(set_flags)
@@ -5556,8 +5554,8 @@ def _linux_strip_vmlinux(ctx, config, input, out):
     prepare_args.add(prepared)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [input, ctx.executable._llvm_objcopy],
+        executable = llvm_objcopy,
+        inputs = [input],
         outputs = [prepared],
         arguments = [prepare_args],
         mnemonic = "LinuxVmlinuxPrepareStrip",
@@ -5569,8 +5567,8 @@ def _linux_strip_vmlinux(ctx, config, input, out):
     strip_args.add(out)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [prepared, ctx.executable._llvm_objcopy],
+        executable = llvm_objcopy,
+        inputs = [prepared],
         outputs = [out],
         arguments = [strip_args],
         mnemonic = "LinuxVmlinuxStrip",
@@ -5613,18 +5611,19 @@ def _linux_kallsyms_object(ctx, compiler, cc_toolchain, feature_configuration, c
         name + ".kallsyms.o",
     )
 
-def _linux_btf_object(ctx, config, input):
+def _linux_btf_object(ctx, cc_toolchain, config, input):
     if config.config_flags.get("CONFIG_DEBUG_INFO_BTF") != "y":
         return None
     if not ctx.executable.pahole:
         fail("linux_vmlinux %s has DEBUG_INFO_BTF enabled and requires pahole" % ctx.label)
 
+    llvm_objcopy = _llvm_objcopy(cc_toolchain)
     btf_vmlinux = ctx.actions.declare_file(ctx.label.name + ".obj/" + input.basename + ".btf")
     pahole_args = ctx.actions.args()
     pahole_args.add("-input", input)
     pahole_args.add("-output", btf_vmlinux)
     pahole_args.add("-env")
-    pahole_args.add(ctx.executable._llvm_objcopy, format = "LLVM_OBJCOPY=%s")
+    pahole_args.add(llvm_objcopy, format = "LLVM_OBJCOPY=%s")
     pahole_args.add("--")
     pahole_args.add(ctx.executable.pahole)
     pahole_args.add("-J")
@@ -5636,7 +5635,7 @@ def _linux_btf_object(ctx, config, input):
         inputs = [input],
         tools = [
             ctx.attr.pahole[DefaultInfo].files_to_run,
-            ctx.attr._llvm_objcopy[DefaultInfo].files_to_run,
+            llvm_objcopy,
         ],
         outputs = [btf_vmlinux],
         arguments = [pahole_args],
@@ -5653,7 +5652,7 @@ def _linux_btf_object(ctx, config, input):
         "big" if config.config_flags.get("CONFIG_CPU_BIG_ENDIAN") == "y" else "little",
     )
     extract_args.add("--")
-    extract_args.add(ctx.executable._llvm_objcopy)
+    extract_args.add(llvm_objcopy)
     extract_args.add("--only-section=.BTF")
     extract_args.add("--set-section-flags")
     extract_args.add(".BTF=alloc,readonly")
@@ -5664,7 +5663,7 @@ def _linux_btf_object(ctx, config, input):
         ctx.actions,
         executable = ctx.executable._btfmutate,
         inputs = [btf_vmlinux],
-        tools = [ctx.attr._llvm_objcopy[DefaultInfo].files_to_run],
+        tools = [llvm_objcopy],
         outputs = [out],
         arguments = [extract_args],
         mnemonic = "LinuxBTFExtract",
@@ -6114,22 +6113,22 @@ def _linux_vmlinux_impl(ctx):
             btf_base,
             False,
         )
-        btf_object = _linux_btf_object(ctx, config, btf_base)
+        btf_object = _linux_btf_object(ctx, cc_toolchain, config, btf_base)
 
     if kallsyms_enabled:
         for i in range(1, 5):
             tmp = ctx.actions.declare_file(ctx.label.name + ".obj/.tmp_vmlinux%d" % i)
             _linux_vmlinux_link(ctx, linker, cc_toolchain, feature_configuration, image_object, image_object_inputs, export_object, version_object, linker_script, kallsyms_object, btf_object, tmp, True)
-            system_map = _linux_system_map(ctx, tmp, ".tmp_vmlinux%d" % i)
+            system_map = _linux_system_map(ctx, cc_toolchain, tmp, ".tmp_vmlinux%d" % i)
             kallsyms_object = _linux_kallsyms_object(ctx, compiler, cc_toolchain, feature_configuration, config, generated_headers, source_root, system_map, ".tmp_vmlinux%d" % i, ctx.executable.kallsyms_tool)
 
     unstripped = ctx.actions.declare_file(ctx.label.name + ".vmlinux.unstripped")
     linked = _linux_vmlinux_link(ctx, linker, cc_toolchain, feature_configuration, image_object, image_object_inputs, export_object, version_object, linker_script, kallsyms_object, btf_object, unstripped, False)
     linked = _linux_resolve_btfids(ctx, config, linked)
-    unstripped = _linux_sorttable(ctx, config, linked)
+    unstripped = _linux_sorttable(ctx, cc_toolchain, config, linked)
     out = ctx.actions.declare_file(ctx.label.name + ".vmlinux")
-    out = _linux_strip_vmlinux(ctx, config, unstripped, out)
-    system_map = _linux_system_map(ctx, out, "System.map")
+    out = _linux_strip_vmlinux(ctx, cc_toolchain, config, unstripped, out)
+    system_map = _linux_system_map(ctx, cc_toolchain, out, "System.map")
     info = LinuxImageInfo(
         archives = image.archives,
         module_objects = image.module_objects,
@@ -6207,24 +6206,12 @@ linux_vmlinux = rule(
             doc = "Kernel-source-specific scripts/sorttable executable. Required when BUILDTIME_TABLE_SORT is enabled.",
             executable = True,
         ),
-        "_llvm_nm": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-nm"),
-            executable = True,
-        ),
         "_btfmutate": attr.label(
             cfg = "exec",
             default = Label("//internal/cmd/btfmutate"),
             executable = True,
         ),
         "_host_cc_toolchain": host_cc_toolchain_attr(exec_group = "host_cc"),
-        "_llvm_objcopy": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-objcopy"),
-            executable = True,
-        ),
         "_modulemodinfo": attr.label(
             cfg = "exec",
             default = Label("//internal/cmd/modulemodinfo"),
@@ -6349,7 +6336,7 @@ def _linux_x86_tool_sibling(tool, name):
         return name
     return parts[0] + "/" + name
 
-def _linux_x86_objcopy(ctx, input, out_relpath, flags):
+def _linux_x86_objcopy(ctx, cc_toolchain, input, out_relpath, flags):
     out = ctx.actions.declare_file(ctx.label.name + ".obj/" + out_relpath)
     args = ctx.actions.args()
     args.add_all(flags)
@@ -6357,8 +6344,8 @@ def _linux_x86_objcopy(ctx, input, out_relpath, flags):
     args.add(out)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [input, ctx.executable._llvm_objcopy],
+        executable = _llvm_objcopy(cc_toolchain),
+        inputs = [input],
         outputs = [out],
         arguments = [args],
         mnemonic = "LinuxX86Objcopy",
@@ -6632,8 +6619,8 @@ def _linux_x86_efi_stub_compile(ctx, compiler, cc_toolchain, feature_configurati
     objcopy_args.add(out)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [compile_out, ctx.executable._llvm_objcopy],
+        executable = _llvm_objcopy(cc_toolchain),
+        inputs = [compile_out],
         outputs = [out],
         arguments = [objcopy_args],
         mnemonic = "LinuxX86EFIStubObjcopy",
@@ -6669,7 +6656,7 @@ def _linux_x86_image_object_outputs(image, exact = [], prefix = ""):
     return out
 
 def _linux_x86_compressed_vmlinux(ctx, compiler, linker, archiver, cc_toolchain, feature_configuration, config, generated_headers, source_root, image, voffset):
-    stripped = _linux_x86_objcopy(ctx, image.output, "arch/x86/boot/compressed/vmlinux.bin", ["-R", ".comment", "-S"])
+    stripped = _linux_x86_objcopy(ctx, cc_toolchain, image.output, "arch/x86/boot/compressed/vmlinux.bin", ["-R", ".comment", "-S"])
     payload_inputs = [stripped]
     if ctx.executable.x86_relocs_tool:
         payload_inputs.append(_linux_x86_relocs(ctx, image.output))
@@ -6974,7 +6961,7 @@ def _linux_x86_setup_bin(ctx, compiler, linker, cc_toolchain, feature_configurat
         mnemonic = "LinuxX86SetupLink",
         progress_message = "Linking Linux x86 setup ELF %{label}",
     )
-    return _linux_x86_objcopy(ctx, setup_elf, "arch/x86/boot/setup.bin", ["-O", "binary"])
+    return _linux_x86_objcopy(ctx, cc_toolchain, setup_elf, "arch/x86/boot/setup.bin", ["-O", "binary"])
 
 def _linux_x86_bzimage_impl(ctx):
     if not ctx.attr.config:
@@ -7018,7 +7005,7 @@ def _linux_x86_bzimage_impl(ctx):
         voffset,
     )
     zoffset = _linux_x86_offsets(ctx, compressed_vmlinux, "zoffset", "arch/x86/boot/zoffset.h")
-    vmlinux_bin = _linux_x86_objcopy(ctx, compressed_vmlinux, "arch/x86/boot/vmlinux.bin", ["-O", "binary", "-R", ".note", "-R", ".comment", "-S"])
+    vmlinux_bin = _linux_x86_objcopy(ctx, cc_toolchain, compressed_vmlinux, "arch/x86/boot/vmlinux.bin", ["-O", "binary", "-R", ".note", "-R", ".comment", "-S"])
     setup_bin = _linux_x86_setup_bin(ctx, compiler, linker, cc_toolchain, feature_configuration, config, generated_headers, source_root, voffset, zoffset)
     out = _linux_x86_bzimage(ctx, setup_bin, vmlinux_bin)
     info = LinuxImageInfo(
@@ -7057,6 +7044,7 @@ def _linux_compressed_image_impl(ctx):
 
 def _linux_objcopy_image_impl(ctx, objcopy_flags):
     image = ctx.attr.image[LinuxImageInfo]
+    cc_toolchain = find_cpp_toolchain(ctx)
     out = ctx.actions.declare_file(ctx.label.name + "." + ctx.attr.extension)
     args = ctx.actions.args()
     args.add_all(objcopy_flags)
@@ -7064,8 +7052,8 @@ def _linux_objcopy_image_impl(ctx, objcopy_flags):
     args.add(out)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
-        inputs = [image.output, ctx.executable._llvm_objcopy],
+        executable = _llvm_objcopy(cc_toolchain),
+        inputs = [image.output],
         outputs = [out],
         arguments = [args],
         mnemonic = "LinuxKernelObjcopyImage",
@@ -7108,12 +7096,6 @@ linux_compressed_image = rule(
         "_insnattr": attr.label(
             cfg = "exec",
             default = Label("//internal/cmd/insnattr"),
-            executable = True,
-        ),
-        "_llvm_objcopy": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-objcopy"),
             executable = True,
         ),
         "_lz4": attr.label(
@@ -7173,13 +7155,14 @@ linux_cache_shape_check = rule(
     doc = "Analysis-time check that shared object variants keep the same provider output across image targets.",
 )
 
-# Narrow private helper surface shared with internal/linux_modules.bzl. Keeping
-# these functions behind one struct avoids making the implementation helpers
-# individual loadable symbols or part of the root public API.
+# Narrow private helper surface shared with sibling internal rules. Keeping these
+# functions behind one struct avoids making them part of the root public API.
 linux_module_cc_helpers = struct(
     compile_flags = _linux_compile_flags,
     configure_features = _cc_feature_configuration,
     cpp_undef_flags = _linux_cpp_undef_flags,
+    llvm_nm = _llvm_nm,
+    llvm_objcopy = _llvm_objcopy,
     module_flags = _linux_module_flags,
     object_name_flags = _linux_object_name_flags,
     source_include_dirs = _linux_ordered_include_dirs,

--- a/internal/linux_rust.bzl
+++ b/internal/linux_rust.bzl
@@ -815,15 +815,16 @@ def _compile_kernel_c(
     )
     return _process_objtool(ctx, config, raw, object_path)
 
-def _objcopy(ctx, input, path, flags):
+def _objcopy(ctx, cc_toolchain, input, path, flags):
     out = ctx.actions.declare_file(ctx.label.name + ".rust_sdk/" + path)
+    llvm_objcopy = linux_module_cc_helpers.llvm_objcopy(cc_toolchain)
     args = ctx.actions.args()
     args.add_all(flags)
     args.add(input)
     args.add(out)
     path_mapped_run(
         ctx.actions,
-        executable = ctx.executable._llvm_objcopy,
+        executable = llvm_objcopy,
         inputs = [input],
         outputs = [out],
         arguments = [args],
@@ -834,6 +835,7 @@ def _objcopy(ctx, input, path, flags):
 
 def _rust_crate(
         ctx,
+        cc_toolchain,
         rust_toolchain,
         rustc_probe,
         config,
@@ -892,23 +894,24 @@ def _rust_crate(
     )
     processed = raw_object
     if objcopy_flags:
-        processed = _objcopy(ctx, raw_object, "rust/" + crate + ".objcopy.o", objcopy_flags)
+        processed = _objcopy(ctx, cc_toolchain, raw_object, "rust/" + crate + ".objcopy.o", objcopy_flags)
     return struct(
         metadata = metadata,
         object = _process_objtool(ctx, config, processed, "rust/" + crate + ".o"),
     )
 
-def _export_header(ctx, object, name):
+def _export_header(ctx, cc_toolchain, object, name):
     symbols = ctx.actions.declare_file(ctx.label.name + ".rust_sdk/rust/." + name + ".nm")
+    llvm_nm = linux_module_cc_helpers.llvm_nm(cc_toolchain)
     nm_args = ctx.actions.args()
-    nm_args.add("-nm", ctx.executable._llvm_nm)
+    nm_args.add("-nm", llvm_nm)
     nm_args.add("-in", object)
     nm_args.add("-out", symbols)
     path_mapped_run(
         ctx.actions,
         executable = ctx.executable._nmrun,
         inputs = [object],
-        tools = [ctx.executable._llvm_nm],
+        tools = [llvm_nm],
         outputs = [symbols],
         arguments = [nm_args],
         mnemonic = "LinuxRustNm",
@@ -1330,6 +1333,7 @@ def _linux_rust_kernel_sdk_impl(ctx):
             crate_flags.extend(["--extern", extern])
         crates[name] = _rust_crate(
             ctx,
+            cc_toolchain,
             rust_toolchain,
             rustc_probe,
             config,
@@ -1380,9 +1384,9 @@ def _linux_rust_kernel_sdk_impl(ctx):
     export_headers = []
     for name in _profile_string_list(export_profile, "crates"):
         if name == "helpers":
-            export_headers.append(_export_header(ctx, helpers, name))
+            export_headers.append(_export_header(ctx, cc_toolchain, helpers, name))
         elif name in crates:
-            export_headers.append(_export_header(ctx, crates[name].object, name))
+            export_headers.append(_export_header(ctx, cc_toolchain, crates[name].object, name))
         else:
             fail("Rust profile exports unavailable crate %r" % name)
     exports_source_path = _validate_profile_path(
@@ -1515,18 +1519,6 @@ linux_rust_kernel_sdk = rule(
             executable = True,
         ),
         "_host_cc_toolchain": host_cc_toolchain_attr(),
-        "_llvm_nm": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-nm"),
-            executable = True,
-        ),
-        "_llvm_objcopy": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("@llvm//tools:llvm-objcopy"),
-            executable = True,
-        ),
         "_nmrun": attr.label(
             cfg = "exec",
             default = Label("//internal/cmd/nmrun"),


### PR DESCRIPTION
## Summary

- mark `buildifier_prebuilt` and `llvm` as root-only development dependencies
- remove the redundant LLVM module extension and register `@llvm//toolchain:all`
- source `llvm-nm` and `llvm-objcopy` from the selected C++ toolchain instead of module-local `@llvm` labels
- consolidate the development-only Rust, tar, and LLVM registrations
- use `//toolchain:all` consistently in the root module, examples, e2e coverage, and documentation
- document the supported Hermetic LLVM toolchain contract
- refresh downstream lockfiles after removing Buildifier from consumer resolution

## Why

This addresses review feedback from bazelbuild/bazel-central-registry#9904 and makes the module metadata match the consumer contract: applications select and register an LLVM C++ toolchain, while linux.bzl consumes its tools through `CcToolchainInfo`.

A development dependency is not visible in linux.bzl's repository mapping when linux.bzl is used transitively. Removing the implicit `@llvm//tools:*` attributes prevents that mapping leak and also allows consumers to rename their direct LLVM repository.

## Validation

- Bazel 9.1: `bazel test //...` (145 tests passed)
- Bazel 8.4.2: `bazel build //... --nobuild`
- Bazel 9.1: built `//:x86_64_kernel` from `examples`
- Bazel 9.1: analyzed x86, arm64, and Rust kernels from `e2e` with LLVM renamed to `@hermetic_llvm`
- Bazel 9.1: built `@e2e_x86_64//:kernel` with the renamed LLVM repository
- `bazel run //:buildifier`
- `git diff --check`
