### PR TITLE
Fix BCR registry fork

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
     with:
       tag_name: ${{ inputs.tag_name }}
-      registry_fork: fionera/bazel-central-registry
+      registry_fork: hermeticbuild/bazel-central-registry
       draft: false
       attest: true
     permissions:


### PR DESCRIPTION
## Summary

- point the BCR publishing workflow at `hermeticbuild/bazel-central-registry`

## Why

The v0.0.2 publish job attempted to push its generated registry branch to `fionera/bazel-central-registry`. The workflow runs as `hermeticbuild-bot`, which received HTTP 403 against that personal fork. The organization-owned BCR fork is the intended push target.

## Impact

Future release publishing jobs will create their BCR submission branch in the Hermetic Build organization fork before opening the upstream registry PR.

## Validation

- workflow YAML parsed successfully
- `git diff --check`
