### PR TITLE
Raise configured target limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
           bazel-bin/x86_64_shared_graph_metadata.json
           3533
           4727
-          110000
+          115000
 
       - name: Upload Bazel profile
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

- raise the shared-kernel-graph configured-target ceiling from 110,000 to 115,000

## Why

The simplified LLVM toolchain registration configures 113,493 targets. The graph's functional sharing metrics remain unchanged at 4,727 memberships deduplicated to 3,533 `LinuxObjectCompile` actions, so this adjusts the analysis-size guard to accommodate the new registration shape.

## Impact

The x86_64 variants CI job will continue enforcing a bounded configured-target count while allowing the current toolchain configuration.

## Validation

- observed current count: 113,493
- workflow YAML validation
- `git diff --check`
