### PR TITLE
Model command-line symbols in include scans

### DIFF
--- a/internal/kconfig/config_footprint.go
+++ b/internal/kconfig/config_footprint.go
@@ -125,13 +125,20 @@ type sourceIncludeSearch struct {
 	includeRoots []string
 	systemRoots  []string
 	afterRoots   []string
+	predefined   map[string]bool
 }
 
 func (s sourceIncludeSearch) cacheKey() string {
-	return "quote=" + strings.Join(s.quoteRoots, "\x00") +
+	key := "quote=" + strings.Join(s.quoteRoots, "\x00") +
 		"\x01include=" + strings.Join(s.includeRoots, "\x00") +
 		"\x01system=" + strings.Join(s.systemRoots, "\x00") +
 		"\x01after=" + strings.Join(s.afterRoots, "\x00")
+	var symbols []string
+	for symbol, defined := range s.predefined {
+		symbols = append(symbols, symbol+"="+strconv.FormatBool(defined))
+	}
+	sort.Strings(symbols)
+	return key + "\x01predefined=" + strings.Join(symbols, "\x00")
 }
 
 func (s sourceIncludeSearch) roots(kind sourceIncludeKind) []string {
@@ -199,11 +206,12 @@ func (s *configSourceScanner) actionIncludeSearch(source string, flags []string)
 		includeRoots: includeRoots,
 		systemRoots:  flagSearch.systemRoots,
 		afterRoots:   flagSearch.afterRoots,
+		predefined:   flagSearch.predefined,
 	}, nil
 }
 
 func sourceIncludeSearchFromFlags(flags []string, source string) (sourceIncludeSearch, error) {
-	search := sourceIncludeSearch{}
+	search := sourceIncludeSearch{predefined: sourceFlagPredefinedSymbols(flags)}
 	pathFlags, err := sourcePathFlags(flags)
 	if err != nil {
 		return sourceIncludeSearch{}, err
@@ -231,6 +239,40 @@ func sourceIncludeSearchFromFlags(flags []string, source string) (sourceIncludeS
 		}
 	}
 	return search, nil
+}
+
+func sourceFlagPredefinedSymbols(flags []string) map[string]bool {
+	result := map[string]bool{}
+	for index := 0; index < len(flags); index++ {
+		flag := flags[index]
+		kind := byte(0)
+		value := ""
+		if flag == "-D" || flag == "-U" {
+			kind = flag[1]
+			if index+1 >= len(flags) {
+				continue
+			}
+			index++
+			value = flags[index]
+		} else if len(flag) > 2 && (strings.HasPrefix(flag, "-D") || strings.HasPrefix(flag, "-U")) {
+			kind = flag[1]
+			value = flag[2:]
+		}
+		if kind == 0 {
+			continue
+		}
+		if name, _, ok := strings.Cut(value, "="); ok {
+			value = name
+		}
+		if name, _, ok := strings.Cut(value, "("); ok {
+			value = name
+		}
+		value = strings.TrimSpace(value)
+		if sourceIdentifier(value) {
+			result[value] = kind == 'D'
+		}
+	}
+	return result
 }
 
 type sourcePathFlag struct {
@@ -869,6 +911,9 @@ func (s *configSourceScanner) scanFile(
 		predefined[symbol] = defined
 	}
 	for symbol, defined := range sourceProfilePredefinedSymbols(profile) {
+		predefined[symbol] = defined
+	}
+	for symbol, defined := range search.predefined {
 		predefined[symbol] = defined
 	}
 	if config != nil {

--- a/internal/kconfig/config_footprint_test.go
+++ b/internal/kconfig/config_footprint_test.go
@@ -36,6 +36,28 @@ func TestIncludePath(t *testing.T) {
 	}
 }
 
+func TestSourceFlagPredefinedSymbols(t *testing.T) {
+	got := sourceFlagPredefinedSymbols([]string{
+		"-DFEATURE",
+		"-DVALUE=7",
+		"-UOPTIONAL_HEADER",
+		"-D",
+		"FUNCTION(x)=x",
+		"-U",
+		"LEGACY",
+	})
+	want := map[string]bool{
+		"FEATURE":         true,
+		"FUNCTION":        true,
+		"LEGACY":          false,
+		"OPTIONAL_HEADER": false,
+		"VALUE":           true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sourceFlagPredefinedSymbols() = %v, want %v", got, want)
+	}
+}
+
 func TestConfigSourceScannerFollowsIncludeClosure(t *testing.T) {
 	root := t.TempDir()
 	mustWriteSource(t, root, "drivers/foo.c", `
@@ -657,6 +679,27 @@ func TestConfigSourceScannerContentGraphRejectsUnresolvedLiteralInclude(t *testi
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("closureForSource() error = %q, want substring %q", err, want)
 		}
+	}
+}
+
+func TestConfigSourceScannerUsesCommandLineUndefines(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/module.c", "#include \"module.h\"\n")
+	mustWriteSource(t, root, "drivers/module.h", "#ifdef OPTIONAL_VENDOR_CONFIG\n#include <missing-vendor-config.h>\n#endif\n")
+	scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
+	search, err := scanner.actionIncludeSearch("drivers/module.c", []string{"-UOPTIONAL_VENDOR_CONFIG"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := scanner.closureForSourceConfigInputsSearchProfile(
+		"drivers/module.c",
+		search,
+		nil,
+		false,
+		nil,
+		sourceScanKernel,
+	); err != nil {
+		t.Fatalf("closure with command-line undefine failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Parse command-line `-D` and `-U` options into the source include scanner's predefined-symbol state.
- Include that state in scanner cache keys.
- Apply command-line definitions after architecture defaults and before Kconfig-derived bindings.
- Cover joined and split flag spellings, values, function-like macros, and a conditionally omitted vendor header.

## Why

The compact Kbuild graph follows literal C includes to determine source inputs. Compiler flags can make those includes active or inactive, so ignoring `-D` and `-U` can incorrectly require headers that the compiler never reads.

## Checks

- `bazel test //internal/kconfig:kconfig_test --test_output=errors`
- `gofmt`
- `git diff --check`