### PR TITLE
Consume Kconfig tool v0.0.24

### DIFF
--- a/internal/kconfig_tool_releases.bzl
+++ b/internal/kconfig_tool_releases.bzl
@@ -5,7 +5,7 @@ Each archive must extract the requested host executables at its root.
 
 visibility("//...")
 
-KCONFIG_TOOL_VERSION = "v0.0.23"
+KCONFIG_TOOL_VERSION = "v0.0.24"
 
 _RELEASE_BASE_URL = "https://github.com/hermeticbuild/linux.bzl/releases/download/kconfig-{version}".format(
     version = KCONFIG_TOOL_VERSION,
@@ -13,27 +13,27 @@ _RELEASE_BASE_URL = "https://github.com/hermeticbuild/linux.bzl/releases/downloa
 
 KCONFIG_TOOL_RELEASES = {
     "darwin_amd64": struct(
-        integrity = "sha256-Iq1JosAcxRm9xmViey7wmfqTqtJUzJ2uTH86OXWbyTg=",
+        integrity = "sha256-ysaULgkGzB8t0LL5mo6FuDSrXWPdrz6ib/YBkyEtF1Y=",
         urls = ["{}/kconfig-darwin-amd64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "darwin_arm64": struct(
-        integrity = "sha256-O1ppy1u/ryEWNbRqOWG7j9yszCQcquwRF4AOWf5n1lg=",
+        integrity = "sha256-Af2lWA49NKvstmkl55zU0QB0wZ8GxxTe77ST/9JtG/8=",
         urls = ["{}/kconfig-darwin-arm64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "linux_amd64": struct(
-        integrity = "sha256-oidCZouZrLHkGbFXNr4tae2Ubz4RFchjFA5oLzJq03U=",
+        integrity = "sha256-C4NSGytF5/ucu9xJaUYTTNmMdkOCnUp/rx0W2MuCqns=",
         urls = ["{}/kconfig-linux-amd64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "linux_arm64": struct(
-        integrity = "sha256-6u0/12Ja1CTizoEJOkmhw7MGsgor2JFLtcn1fUOVXJg=",
+        integrity = "sha256-3kRUMbP9MdNJXU54rNCuiGt2p+BWvcNA4465uzJFlQA=",
         urls = ["{}/kconfig-linux-arm64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "windows_amd64": struct(
-        integrity = "sha256-rmu+frbPydXcIdnO1Ggad+NqyRl5K4Xtd+33L/XshAs=",
+        integrity = "sha256-c85cB7iDgUR+8D7z8YRtDZpnpKhaSKlsHhUY8dBB7YM=",
         urls = ["{}/kconfig-windows-amd64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
     "windows_arm64": struct(
-        integrity = "sha256-l2vUamNEZERwRyzSqIj0ew/s/QvrdlMdOHCU2fNI48E=",
+        integrity = "sha256-cj0s3Egbu+9IjH8AR0RNX69eOtD/odjejkRYwd1iit0=",
         urls = ["{}/kconfig-windows-arm64.tar.zst".format(_RELEASE_BASE_URL)],
     ),
 }


### PR DESCRIPTION
## What changed

Pin the repository-rule Kconfig tools to the newly published `kconfig-v0.0.24` release for all six supported host platforms.

Release: https://github.com/hermeticbuild/linux.bzl/releases/tag/kconfig-v0.0.24

## Why

This release contains command-line `-D`/`-U` modeling for conditional source include scans, merged in #64.

## Checks

- Verified all release asset integrities against `kconfig_tool_releases.metadata`
- `bazel test //internal/tests:kconfig_tool_filename_test --test_output=errors`