### PR TITLE
Support conditional overlaid Kbuild roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ for configured images, as shown above.
 | `patches` | Deterministic patch files |
 | `patch_strip` | Strip count for `patches` |
 | `source_overlays` | In-tree destination directories mapped to marker files in external source roots |
-| `module_kbuild_roots` | Overlaid directories added to the kernel Kbuild graph |
+| `module_kbuild_roots` | Overlaid Kbuild directories mapped to Kconfig expressions controlling graph inclusion; use `"y"` for an unconditional root |
 | `module_kconfig_roots` | Overlaid Kconfig files sourced by the root Kconfig |
 | `module_make_vars` | Deterministic variables needed while parsing overlaid Kconfig/Kbuild files |
 
@@ -324,9 +324,9 @@ linux_source_repository(
     source_overlays = {
         "drivers/net/ethernet/broadcom/sdklt": "@sai_bcm_modules//:platform/broadcom/saibcm-modules/sdklt/Makefile",
     },
-    module_kbuild_roots = [
-        "drivers/net/ethernet/broadcom/sdklt/linux/bde",
-    ],
+    module_kbuild_roots = {
+        "drivers/net/ethernet/broadcom/sdklt/linux/bde": "X86",
+    },
     module_make_vars = {
         "BDE_CPPFLAGS": "-UBCMDRD_INCLUDE_CUSTOM_CONFIG",
         "SDK": "$(srctree)/drivers/net/ethernet/broadcom/sdklt",
@@ -338,6 +338,11 @@ If a vendor tree has Kconfig entry points, list their in-tree paths in
 `module_kconfig_roots`. Selecting the vendor symbol as `m` makes its module a
 normal output of `@configured_kernel//:modules`, including the usual objtool,
 modpost, module-link, and optional BTF stages.
+
+`module_kbuild_roots` values use Kconfig expression syntax (`X86`, not
+`CONFIG_X86`). linux.bzl lowers conditional expressions to hidden tristate
+selectors before adding the directory to the root Kbuild. Use `"y"` when the
+root must be traversed for every configured architecture.
 
 ## Why
 

--- a/internal/linux_source_repository.bzl
+++ b/internal/linux_source_repository.bzl
@@ -31,6 +31,7 @@ _KERNEL_RELEASES = {
 _TOOLS_BUILD_FILE = "Build"
 _TOOLS_BUILD_FILE_RELOCATED = "Build.linux-bzl"
 _TOOLS_MAX_DEPTH = 64
+_SOURCE_OVERLAY_FILES_MARKER = "    # __LINUX_BZL_SOURCE_OVERLAY_FILES__"
 
 def _in_tree_path(path, what):
     normalized = path.replace("\\", "/").strip("/")
@@ -45,6 +46,7 @@ def _in_tree_path(path, what):
 
 def _stage_source_overlays(rctx):
     destinations = []
+    staged_files = []
     for destination in sorted(rctx.attr.source_overlays.keys()):
         normalized = _in_tree_path(destination, "source_overlays destination")
         marker = rctx.path(rctx.attr.source_overlays[destination])
@@ -75,19 +77,47 @@ def _stage_source_overlays(rctx):
         if not files:
             fail("source_overlays[%r] identifies an empty source tree" % destination)
         for relative in sorted(files.keys()):
-            rctx.symlink(files[relative], normalized + "/" + relative)
+            staged = normalized + "/" + relative
+            rctx.symlink(files[relative], staged)
+            staged_files.append(staged)
         destinations.append(normalized)
-    return destinations
+    return struct(
+        destinations = sorted(destinations),
+        files = sorted(staged_files),
+    )
 
-def _integrate_in_tree_modules(rctx):
-    kbuild_roots = []
-    for path in rctx.attr.module_kbuild_roots:
-        path = _in_tree_path(path, "module_kbuild_roots entry")
-        if path in kbuild_roots:
-            fail("duplicate module_kbuild_roots entry %r" % path)
+def _module_kbuild_root_symbol(path):
+    normalized = []
+    previous_was_separator = False
+    for character in path.upper().elems():
+        if (
+            (character >= "A" and character <= "Z") or
+            (character >= "0" and character <= "9")
+        ):
+            normalized.append(character)
+            previous_was_separator = False
+        elif not previous_was_separator:
+            normalized.append("_")
+            previous_was_separator = True
+    return "LINUX_BZL_MODULE_KBUILD_ROOT_" + "".join(normalized).strip("_")
+
+def _module_kbuild_roots(rctx):
+    roots = {}
+    for raw_path, expression in rctx.attr.module_kbuild_roots.items():
+        path = _in_tree_path(raw_path, "module_kbuild_roots key")
+        if path in roots:
+            fail("duplicate normalized module_kbuild_roots key %r" % path)
+        if not expression.strip():
+            fail("module_kbuild_roots[%r] must be a non-empty Kconfig expression" % raw_path)
+        if "\n" in expression or "\r" in expression:
+            fail("module_kbuild_roots[%r] must be a single-line Kconfig expression" % raw_path)
         if not rctx.path(path + "/Kbuild").exists and not rctx.path(path + "/Makefile").exists:
             fail("module Kbuild root %r contains neither Kbuild nor Makefile" % path)
-        kbuild_roots.append(path)
+        roots[path] = expression
+    return roots
+
+def _integrate_in_tree_modules(rctx):
+    kbuild_roots = _module_kbuild_roots(rctx)
 
     kconfig_roots = []
     for path in rctx.attr.module_kconfig_roots:
@@ -101,8 +131,36 @@ def _integrate_in_tree_modules(rctx):
     if kbuild_roots:
         root = rctx.path("Kbuild")
         content = rctx.read(root).rstrip() + "\n\n# In-tree module roots added by linux.bzl.\n"
-        content += "\n".join(["obj-y += %s/" % path for path in kbuild_roots]) + "\n"
+        root_lines = []
+        selectors = []
+        selector_paths = {}
+        for path in sorted(kbuild_roots.keys()):
+            expression = kbuild_roots[path]
+            if expression == "y":
+                root_lines.append("obj-y += %s/" % path)
+                continue
+            selector = _module_kbuild_root_symbol(path)
+            previous_path = selector_paths.get(selector)
+            if previous_path != None:
+                fail(
+                    "module_kbuild_roots keys %r and %r generate the same hidden Kconfig symbol %s" %
+                    (previous_path, path, selector),
+                )
+            selector_paths[selector] = path
+            selectors.append((selector, expression))
+            root_lines.append("obj-$(CONFIG_%s) += %s/" % (selector, path))
+        content += "\n".join(root_lines) + "\n"
         rctx.file(root, content, executable = False)
+
+        if selectors:
+            root = rctx.path("Kconfig")
+            content = rctx.read(root).rstrip() + "\n\n# In-tree module root selectors added by linux.bzl.\n"
+            content += "\n\n".join([
+                "config %s\n\tdef_tristate %s" % (selector, expression)
+                for selector, expression in selectors
+            ]) + "\n"
+            rctx.file(root, content, executable = False)
+
     if kconfig_roots:
         root = rctx.path("Kconfig")
         content = rctx.read(root).rstrip() + "\n\n# In-tree module Kconfig roots added by linux.bzl.\n"
@@ -192,7 +250,7 @@ def _linux_source_repository_impl(rctx):
     for patch in rctx.attr.patches:
         rctx.patch(patch, strip = rctx.attr.patch_strip)
     _normalize_tools_build_files(rctx)
-    overlay_destinations = _stage_source_overlays(rctx)
+    overlays = _stage_source_overlays(rctx)
     _integrate_in_tree_modules(rctx)
 
     makefile = rctx.path("Makefile")
@@ -218,13 +276,19 @@ def _linux_source_repository_impl(rctx):
         "@platforms",
         repository_prefix(rctx.attr._platforms_x86_64),
     )
+    if _SOURCE_OVERLAY_FILES_MARKER not in source_build:
+        fail("source repository BUILD template is missing the overlay files marker")
+    source_build = source_build.replace(
+        _SOURCE_OVERLAY_FILES_MARKER,
+        "\n".join(["    %r," % path for path in overlays.files]),
+    )
     rctx.file("BUILD.bazel", source_build, executable = False)
     rctx.file(
         ".linux-bzl-source.json",
         json.encode({
             "integrity": integrity,
             "module_make_vars": rctx.attr.module_make_vars,
-            "overlay_destinations": overlay_destinations,
+            "overlay_destinations": overlays.destinations,
             "protocol": LINUX_SOURCE_REPOSITORY_PROTOCOL,
             "version": actual_version,
         }) + "\n",
@@ -238,8 +302,8 @@ linux_source_repository = repository_rule(
         "integrity": attr.string(
             doc = "SHA-256 SRI digest required with explicit urls.",
         ),
-        "module_kbuild_roots": attr.string_list(
-            doc = "In-tree directories whose Kbuild or Makefile roots are added to the kernel object graph.",
+        "module_kbuild_roots": attr.string_dict(
+            doc = "In-tree Kbuild or Makefile roots mapped to Kconfig expressions controlling their inclusion; use y for unconditional roots.",
         ),
         "module_kconfig_roots": attr.string_list(
             doc = "In-tree Kconfig files sourced by the kernel root Kconfig.",

--- a/internal/tests/source_repo/source_repo_test.go
+++ b/internal/tests/source_repo/source_repo_test.go
@@ -32,8 +32,29 @@ func TestSourceRepositoryExportsDirectories(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(content), `glob(["**"], exclude_directories = 0)`) {
+	if !strings.Contains(string(content), `exclude_directories = 0`) {
 		t.Fatal("source repository exports must include directories for consumer include-path labels")
+	}
+}
+
+func TestSourceRepositoryExplicitlyExportsOverlayFiles(t *testing.T) {
+	path := filepath.Join(
+		os.Getenv("TEST_SRCDIR"),
+		os.Getenv("TEST_WORKSPACE"),
+		"source_repo.BUILD.bazel",
+	)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`_SOURCE_OVERLAY_FILES = [`,
+		`exclude = _SOURCE_OVERLAY_FILES`,
+		`) + _SOURCE_OVERLAY_FILES`,
+	} {
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("source repository overlay export contract is missing %s", want)
+		}
 	}
 }
 

--- a/sonic_e2e/BUILD.bazel
+++ b/sonic_e2e/BUILD.bazel
@@ -5,6 +5,11 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["sonic.config"])
 
+filegroup(
+    name = "ngbde_main_source",
+    srcs = ["@sonic_linux_6_18_39//:drivers/net/ethernet/broadcom/sdklt/linux/bde/ngbde_main.c"],
+)
+
 select_file(
     name = "linux_ngbde_ko",
     srcs = "@sonic_kernel//:modules",
@@ -13,5 +18,9 @@ select_file(
 
 build_test(
     name = "sonic_linux_ngbde_module_test",
-    targets = [":linux_ngbde_ko"],
+    targets = [
+        ":linux_ngbde_ko",
+        ":ngbde_main_source",
+        "@sonic_arm64_kernel//:modules",
+    ],
 )

--- a/sonic_e2e/MODULE.bazel
+++ b/sonic_e2e/MODULE.bazel
@@ -32,9 +32,9 @@ linux_source_repository = use_repo_rule(
 
 linux_source_repository(
     name = "sonic_linux_6_18_39",
-    module_kbuild_roots = [
-        "drivers/net/ethernet/broadcom/sdklt/linux/bde",
-    ],
+    module_kbuild_roots = {
+        "drivers/net/ethernet/broadcom/sdklt/linux/bde": "X86",
+    },
     module_make_vars = {
         "BDE_CPPFLAGS": "-UBCMDRD_INCLUDE_CUSTOM_CONFIG",
         "SDK": "$(srctree)/drivers/net/ethernet/broadcom/sdklt",
@@ -57,4 +57,15 @@ linux_images.image(
     platform = "@llvm//platforms:linux_x86_64",
     source = "@sonic_linux_6_18_39//:Kconfig",
 )
-use_repo(linux_images, "sonic_kernel")
+linux_images.image(
+    name = "sonic_arm64_kernel",
+    config = "//:sonic.config",
+    config_mode = "allnoconfig",
+    platform = "@llvm//platforms:linux_arm64",
+    source = "@sonic_linux_6_18_39//:Kconfig",
+)
+use_repo(
+    linux_images,
+    "sonic_arm64_kernel",
+    "sonic_kernel",
+)

--- a/sonic_e2e/MODULE.bazel.lock
+++ b/sonic_e2e/MODULE.bazel.lock
@@ -21,8 +21,6 @@
     "https://bcr.bazel.build/modules/apple_support/1.24.1/MODULE.bazel": "f46e8ddad60aef170ee92b2f3d00ef66c147ceafea68b6877cb45bd91737f5f8",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
     "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
-    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/MODULE.bazel": "37c764292861c2f70314efa9846bb6dbb44fc0308903b3285da6528305450183",
-    "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/source.json": "605086bbc197743a0d360f7ddc550a1d4dfa0441bc807236e17170f636153348",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
@@ -235,8 +233,8 @@
     "https://bcr.bazel.build/modules/rules_python/1.6.3/MODULE.bazel": "a7b80c42cb3de5ee2a5fa1abc119684593704fcd2fec83165ebe615dec76574f",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
     "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
-    "https://bcr.bazel.build/modules/rules_rs/0.0.98/MODULE.bazel": "f9fd17e0330506efb3c1bf9aa9352fc81013e6d9af9521ccd5a5b3ce3bb81ffa",
-    "https://bcr.bazel.build/modules/rules_rs/0.0.98/source.json": "f8e639ec93ce46084d52466cec576bb67bdbedf42274ed88ca5993078d92fe7a",
+    "https://bcr.bazel.build/modules/rules_rs/0.0.102/MODULE.bazel": "6c64a272531e59dc2a55726117a4ca3161c6301fd69af3bd1038465730e86632",
+    "https://bcr.bazel.build/modules/rules_rs/0.0.102/source.json": "e0bb950a7126037e2bf5b341e88012fd393d68715489dccce54780f50e6df9ca",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
@@ -271,31 +269,10 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
-      "general": {
-        "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "thB5TswUhz1qnY0LcGOE3geqHuGYrGAyYCkQg0r9p6w=",
-        "recordedInputs": [
-          "REPO_MAPPING:aspect_tools_telemetry+,bazel_lib bazel_lib+",
-          "REPO_MAPPING:aspect_tools_telemetry+,bazel_skylib bazel_skylib+"
-        ],
-        "generatedRepoSpecs": {
-          "aspect_tools_telemetry_report": {
-            "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
-            "attributes": {
-              "deps": {
-                "rules_rs": "0.0.98",
-                "aspect_tools_telemetry": "0.3.3"
-              }
-            }
-          }
-        }
-      }
-    },
     "@@linux.bzl+//:extensions.bzl%linux_images": {
       "os:linux,arch:amd64": {
-        "bzlTransitiveDigest": "VKeWW4FolCR/HuXnKZEUnWijBmYGaoYI4j9Kg+bs6Kc=",
-        "usagesDigest": "qtRD7RRVcTjhSbPwoaYuBIVStgwPEyAFqWG405/AWjs=",
+        "bzlTransitiveDigest": "i8JU4u+DHOljB6j2Oe7hzT5Ne5gyu9R2+/3nvIJYk5A=",
+        "usagesDigest": "VZguVL3YKLGqZFO9pRV4Bbjf+I1HPbujfKZ3EuVNCsk=",
         "recordedInputs": [
           "REPO_MAPPING:,llvm llvm+",
           "REPO_MAPPING:,sonic_linux_6_18_39 +linux_source_repository+sonic_linux_6_18_39",
@@ -304,6 +281,63 @@
           "REPO_MAPPING:llvm+,llvm-toolchain-minimal-22.1.8-linux-amd64 llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64"
         ],
         "generatedRepoSpecs": {
+          "sonic_arm64_kernel__linux_graph__x86_64": {
+            "repoRuleId": "@@linux.bzl+//internal:linux_image_repository.bzl%linux_image",
+            "attributes": {
+              "config": "@@//:sonic.config",
+              "config_mode": "allnoconfig",
+              "overlays": {},
+              "platform": "@@llvm+//platforms:linux_arm64",
+              "probe_cc": "@@llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64//:bin/clang",
+              "probe_ld": "@@llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64//:bin/ld.lld",
+              "source": "@@+linux_source_repository+sonic_linux_6_18_39//:Kconfig",
+              "target_profile": "x86_64",
+              "linux_arch": "x86",
+              "target_triple": "x86_64-linux-gnu"
+            }
+          },
+          "sonic_arm64_kernel__linux_graph__aarch64": {
+            "repoRuleId": "@@linux.bzl+//internal:linux_image_repository.bzl%linux_image",
+            "attributes": {
+              "config": "@@//:sonic.config",
+              "config_mode": "allnoconfig",
+              "overlays": {},
+              "platform": "@@llvm+//platforms:linux_arm64",
+              "probe_cc": "@@llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64//:bin/clang",
+              "probe_ld": "@@llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64//:bin/ld.lld",
+              "source": "@@+linux_source_repository+sonic_linux_6_18_39//:Kconfig",
+              "target_profile": "aarch64",
+              "linux_arch": "arm64",
+              "target_triple": "aarch64-linux-gnu"
+            }
+          },
+          "sonic_arm64_kernel__linux_graph__armv7": {
+            "repoRuleId": "@@linux.bzl+//internal:linux_image_repository.bzl%linux_image",
+            "attributes": {
+              "config": "@@//:sonic.config",
+              "config_mode": "allnoconfig",
+              "overlays": {},
+              "platform": "@@llvm+//platforms:linux_arm64",
+              "probe_cc": "@@llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64//:bin/clang",
+              "probe_ld": "@@llvm++llvm_toolchain_minimal+llvm-toolchain-minimal-22.1.8-linux-amd64//:bin/ld.lld",
+              "source": "@@+linux_source_repository+sonic_linux_6_18_39//:Kconfig",
+              "target_profile": "armv7",
+              "linux_arch": "arm",
+              "target_triple": "arm-linux-gnueabi"
+            }
+          },
+          "sonic_arm64_kernel": {
+            "repoRuleId": "@@linux.bzl+//internal:linux_image_extension.bzl%_linux_image_facade_repository",
+            "attributes": {
+              "graph_repos": {
+                "x86_64": "sonic_arm64_kernel__linux_graph__x86_64",
+                "aarch64": "sonic_arm64_kernel__linux_graph__aarch64",
+                "armv7": "sonic_arm64_kernel__linux_graph__armv7"
+              },
+              "platform": "@@llvm+//platforms:linux_arm64",
+              "variants": []
+            }
+          },
           "sonic_kernel__linux_graph__x86_64": {
             "repoRuleId": "@@linux.bzl+//internal:linux_image_repository.bzl%linux_image",
             "attributes": {
@@ -1020,6 +1054,7 @@
       "jiff_0.2.23": "{\"dependencies\":[{\"kind\":\"dev\",\"name\":\"anyhow\",\"req\":\"^1.0.81\"},{\"features\":[\"serde\"],\"kind\":\"dev\",\"name\":\"chrono\",\"req\":\"^0.4.38\"},{\"kind\":\"dev\",\"name\":\"chrono-tz\",\"req\":\"^0.10.0\"},{\"kind\":\"dev\",\"name\":\"hifitime\",\"req\":\"^3.9.0\",\"target\":\"cfg(not(target_family = \\\"wasm\\\"))\"},{\"kind\":\"dev\",\"name\":\"humantime\",\"req\":\"^2.1.0\"},{\"kind\":\"dev\",\"name\":\"insta\",\"req\":\"^1.39.0\"},{\"name\":\"jiff-static\",\"req\":\"=0.2.23\",\"target\":\"cfg(any())\"},{\"name\":\"jiff-static\",\"optional\":true,\"req\":\"^0.2\"},{\"name\":\"jiff-tzdb\",\"optional\":true,\"req\":\"^0.1.6\"},{\"name\":\"jiff-tzdb-platform\",\"optional\":true,\"req\":\"^0.1.3\",\"target\":\"cfg(any(windows, target_family = \\\"wasm\\\"))\"},{\"name\":\"js-sys\",\"optional\":true,\"req\":\"^0.3.50\",\"target\":\"cfg(all(any(target_arch = \\\"wasm32\\\", target_arch = \\\"wasm64\\\"), target_os = \\\"unknown\\\"))\"},{\"default_features\":false,\"name\":\"log\",\"optional\":true,\"req\":\"^0.4.21\"},{\"kind\":\"dev\",\"name\":\"log\",\"req\":\"^0.4.21\"},{\"default_features\":false,\"name\":\"portable-atomic\",\"req\":\"^1.10.0\",\"target\":\"cfg(not(target_has_atomic = \\\"ptr\\\"))\"},{\"default_features\":false,\"name\":\"portable-atomic-util\",\"req\":\"^0.2.4\",\"target\":\"cfg(not(target_has_atomic = \\\"ptr\\\"))\"},{\"default_features\":false,\"kind\":\"dev\",\"name\":\"quickcheck\",\"req\":\"^1.0.3\"},{\"features\":[\"derive\"],\"kind\":\"dev\",\"name\":\"serde\",\"req\":\"^1.0.203\"},{\"default_features\":false,\"name\":\"serde_core\",\"optional\":true,\"req\":\"^1.0.221\"},{\"kind\":\"dev\",\"name\":\"serde_json\",\"req\":\"^1.0.117\"},{\"kind\":\"dev\",\"name\":\"serde_yaml\",\"req\":\"^0.9.34\"},{\"kind\":\"dev\",\"name\":\"tabwriter\",\"req\":\"^1.4.0\"},{\"features\":[\"local-offset\",\"macros\",\"parsing\"],\"kind\":\"dev\",\"name\":\"time\",\"req\":\"^0.3.36\"},{\"kind\":\"dev\",\"name\":\"time-tz\",\"req\":\"^2.0.0\"},{\"kind\":\"dev\",\"name\":\"tzfile\",\"req\":\"^0.1.3\"},{\"kind\":\"dev\",\"name\":\"walkdir\",\"req\":\"^2.5.0\"},{\"name\":\"wasm-bindgen\",\"optional\":true,\"req\":\"^0.2.70\",\"target\":\"cfg(all(any(target_arch = \\\"wasm32\\\", target_arch = \\\"wasm64\\\"), target_os = \\\"unknown\\\"))\"},{\"default_features\":false,\"features\":[\"Win32_Foundation\",\"Win32_System_Time\"],\"name\":\"windows-sys\",\"optional\":true,\"req\":\">=0.52.0, <=0.61\",\"target\":\"cfg(windows)\"}],\"features\":{\"alloc\":[\"serde_core?/alloc\",\"portable-atomic-util/alloc\"],\"default\":[\"std\",\"tz-system\",\"tz-fat\",\"tzdb-bundle-platform\",\"tzdb-zoneinfo\",\"tzdb-concatenated\",\"perf-inline\"],\"js\":[\"dep:wasm-bindgen\",\"dep:js-sys\"],\"logging\":[\"dep:log\"],\"perf-inline\":[],\"serde\":[\"dep:serde_core\"],\"static\":[\"static-tz\",\"jiff-static?/tzdb\"],\"static-tz\":[\"dep:jiff-static\"],\"std\":[\"alloc\",\"log?/std\",\"serde_core?/std\"],\"tz-fat\":[\"jiff-static?/tz-fat\"],\"tz-system\":[\"std\",\"dep:windows-sys\"],\"tzdb-bundle-always\":[\"dep:jiff-tzdb\",\"alloc\"],\"tzdb-bundle-platform\":[\"dep:jiff-tzdb-platform\",\"alloc\"],\"tzdb-concatenated\":[\"std\"],\"tzdb-zoneinfo\":[\"std\"]}}",
       "jiff_0.2.24": "{\"dependencies\":[{\"kind\":\"dev\",\"name\":\"anyhow\",\"req\":\"^1.0.81\"},{\"features\":[\"serde\"],\"kind\":\"dev\",\"name\":\"chrono\",\"req\":\"^0.4.38\"},{\"kind\":\"dev\",\"name\":\"chrono-tz\",\"req\":\"^0.10.0\"},{\"kind\":\"dev\",\"name\":\"hifitime\",\"req\":\"^3.9.0\",\"target\":\"cfg(not(target_family = \\\"wasm\\\"))\"},{\"kind\":\"dev\",\"name\":\"humantime\",\"req\":\"^2.1.0\"},{\"kind\":\"dev\",\"name\":\"insta\",\"req\":\"^1.39.0\"},{\"name\":\"jiff-static\",\"req\":\"=0.2.24\",\"target\":\"cfg(any())\"},{\"name\":\"jiff-static\",\"optional\":true,\"req\":\"^0.2\"},{\"name\":\"jiff-tzdb\",\"optional\":true,\"req\":\"^0.1.6\"},{\"name\":\"jiff-tzdb-platform\",\"optional\":true,\"req\":\"^0.1.3\",\"target\":\"cfg(any(windows, target_family = \\\"wasm\\\"))\"},{\"name\":\"js-sys\",\"optional\":true,\"req\":\"^0.3.50\",\"target\":\"cfg(all(any(target_arch = \\\"wasm32\\\", target_arch = \\\"wasm64\\\"), target_os = \\\"unknown\\\"))\"},{\"default_features\":false,\"name\":\"log\",\"optional\":true,\"req\":\"^0.4.21\"},{\"kind\":\"dev\",\"name\":\"log\",\"req\":\"^0.4.21\"},{\"default_features\":false,\"name\":\"portable-atomic\",\"req\":\"^1.10.0\",\"target\":\"cfg(not(target_has_atomic = \\\"ptr\\\"))\"},{\"default_features\":false,\"name\":\"portable-atomic-util\",\"req\":\"^0.2.4\",\"target\":\"cfg(not(target_has_atomic = \\\"ptr\\\"))\"},{\"default_features\":false,\"kind\":\"dev\",\"name\":\"quickcheck\",\"req\":\"^1.0.3\"},{\"features\":[\"derive\"],\"kind\":\"dev\",\"name\":\"serde\",\"req\":\"^1.0.203\"},{\"default_features\":false,\"name\":\"serde_core\",\"optional\":true,\"req\":\"^1.0.221\"},{\"kind\":\"dev\",\"name\":\"serde_json\",\"req\":\"^1.0.117\"},{\"kind\":\"dev\",\"name\":\"serde_yaml\",\"req\":\"^0.9.34\"},{\"kind\":\"dev\",\"name\":\"tabwriter\",\"req\":\"^1.4.0\"},{\"features\":[\"local-offset\",\"macros\",\"parsing\"],\"kind\":\"dev\",\"name\":\"time\",\"req\":\"^0.3.36\"},{\"kind\":\"dev\",\"name\":\"time-tz\",\"req\":\"^2.0.0\"},{\"kind\":\"dev\",\"name\":\"tzfile\",\"req\":\"^0.1.3\"},{\"kind\":\"dev\",\"name\":\"walkdir\",\"req\":\"^2.5.0\"},{\"name\":\"wasm-bindgen\",\"optional\":true,\"req\":\"^0.2.70\",\"target\":\"cfg(all(any(target_arch = \\\"wasm32\\\", target_arch = \\\"wasm64\\\"), target_os = \\\"unknown\\\"))\"},{\"default_features\":false,\"features\":[\"Win32_Foundation\",\"Win32_System_Time\"],\"name\":\"windows-sys\",\"optional\":true,\"req\":\">=0.52.0, <=0.61\",\"target\":\"cfg(windows)\"}],\"features\":{\"alloc\":[\"serde_core?/alloc\",\"portable-atomic-util/alloc\"],\"default\":[\"std\",\"tz-system\",\"tz-fat\",\"tzdb-bundle-platform\",\"tzdb-zoneinfo\",\"tzdb-concatenated\",\"perf-inline\"],\"js\":[\"dep:wasm-bindgen\",\"dep:js-sys\"],\"logging\":[\"dep:log\"],\"perf-inline\":[],\"serde\":[\"dep:serde_core\"],\"static\":[\"static-tz\",\"jiff-static?/tzdb\"],\"static-tz\":[\"dep:jiff-static\"],\"std\":[\"alloc\",\"log?/std\",\"serde_core?/std\"],\"tz-fat\":[\"jiff-static?/tz-fat\"],\"tz-system\":[\"std\",\"dep:windows-sys\"],\"tzdb-bundle-always\":[\"dep:jiff-tzdb\",\"alloc\"],\"tzdb-bundle-platform\":[\"dep:jiff-tzdb-platform\",\"alloc\"],\"tzdb-concatenated\":[\"std\"],\"tzdb-zoneinfo\":[\"std\"]}}",
       "js-sys_0.3.82": "{\"dependencies\":[{\"default_features\":false,\"name\":\"once_cell\",\"req\":\"^1.12\"},{\"default_features\":false,\"name\":\"wasm-bindgen\",\"req\":\"=0.2.105\"}],\"features\":{\"default\":[\"std\"],\"std\":[\"wasm-bindgen/std\"]}}",
+      "jsonc-parser_0.26.2": "{\"dependencies\":[{\"name\":\"indexmap\",\"optional\":true,\"req\":\"^2.2.6\"},{\"kind\":\"dev\",\"name\":\"pretty_assertions\",\"req\":\"^1.0.0\"},{\"name\":\"serde_json\",\"optional\":true,\"req\":\"^1.0\"},{\"name\":\"unicode-width\",\"optional\":true,\"req\":\"^0.2.0\"}],\"features\":{\"cst\":[],\"error_unicode_width\":[\"unicode-width\"],\"preserve_order\":[\"indexmap\",\"serde_json/preserve_order\"],\"serde\":[\"serde_json\"]}}",
       "leb128_0.2.6": "{\"dependencies\":[{\"kind\":\"dev\",\"name\":\"quickcheck\",\"req\":\"^1.1\"}],\"features\":{\"nightly\":[]}}",
       "leb128fmt_0.1.0": "{\"dependencies\":[],\"features\":{\"alloc\":[],\"default\":[\"std\"],\"std\":[]}}",
       "libc_0.2.183": "{\"dependencies\":[{\"name\":\"rustc-std-workspace-core\",\"optional\":true,\"req\":\"^1.0.1\"}],\"features\":{\"align\":[],\"const-extern-fn\":[],\"default\":[\"std\"],\"extra_traits\":[],\"rustc-dep-of-std\":[\"align\",\"rustc-std-workspace-core\"],\"std\":[],\"use_std\":[\"std\"]}}",

--- a/source_repo.BUILD.bazel
+++ b/source_repo.BUILD.bazel
@@ -2,8 +2,16 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
+_SOURCE_OVERLAY_FILES = [
+    # __LINUX_BZL_SOURCE_OVERLAY_FILES__
+]
+
 exports_files(
-    glob(["**"], exclude_directories = 0),
+    glob(
+        ["**"],
+        exclude = _SOURCE_OVERLAY_FILES,
+        exclude_directories = 0,
+    ) + _SOURCE_OVERLAY_FILES,
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
## Summary

- export every staged `source_overlays` file as a public Bazel source target
- make `module_kbuild_roots` a path-to-Kconfig-expression mapping, with `"y"` for unconditional roots
- lower conditional roots through deterministic hidden tristate selectors
- validate one SONiC source repository across x86_64 and ARM64, including a direct overlaid source label

## Why

Overlay files existed in the generated repository but were not declared targets, and module roots were always added to the Kbuild graph. That made vendor trees difficult to consume directly and prevented one overlaid source repository from serving multiple architectures safely.

Closes #66.
Closes #71.

## Validation

- `TEST_SRCDIR=/workspace/linux.bzl-source-pr TEST_WORKSPACE=. go test ./internal/tests/source_repo -count=1`
- `bazel test //internal/tests/source_repo:source_repo_test --test_output=errors`
- integration build of `//:sonic_linux_ngbde_module_test`, which compiled the real `linux_ngbde.ko` and resolved the same source repository for ARM64 (3,434 actions)
