### PR TITLE
Fix architecture-specific Kconfig graph inputs

### DIFF
--- a/KCONFIG_RELEASING.md
+++ b/KCONFIG_RELEASING.md
@@ -51,14 +51,17 @@ label required for Kbuild-compatible post-processing.
    source trees on x86_64 and arm64. Cover C and assembly exports, generated C
    sources, built-in and external C modules, and verify that extended, DWARF,
    and Rust module-versioning paths fail closed.
-8. Exercise an empty `CONFIG_SYSTEM_TRUSTED_KEYS` configuration with
+8. Exercise x86 and RISC-V purgatory with their per-source preprocessor
+   contexts, ARM64 KVM generated `hyp_constants.h`, compiler-provided ARM NEON
+   headers, and a provably inactive legacy `MODVERSIONS` include.
+9. Exercise an empty `CONFIG_SYSTEM_TRUSTED_KEYS` configuration with
    `CONFIG_SYSTEM_TRUSTED_KEYRING=y`, including dm-verity root-hash signature
    verification. Verify that non-empty certificate, revocation, blacklist,
    and module-signing inputs still fail closed.
-9. Verify that unsupported source layouts, unresolved Make expressions,
+10. Verify that unsupported source layouts, unresolved Make expressions,
    incomplete leaf objects, and unsupported Rust profiles fail with actionable
    errors.
-10. Build the six platform archives twice from clean output trees and compare
+11. Build the six platform archives twice from clean output trees and compare
    their SHA-256 digests.
 
 Each deterministic `.tar.zst` archive must contain exactly two executables at

--- a/internal/kconfig/compact.go
+++ b/internal/kconfig/compact.go
@@ -1591,15 +1591,12 @@ func (memo compactVariantMemo) variantForStack(
 	forceAllGeneratedHeaders := false
 	if source != "" {
 		flags := normalizeSourceRootFlags(filterResolvedKbuildFlags(object.flags, source), opts.SourceRoot)
-		includeDirs, err := includeDirsFromFlags(flags, source)
-		if err != nil {
-			return CompactObjectVariant{}, fmt.Errorf(
-				"model source include flags for %s: %w",
-				name,
-				err,
-			)
-		}
-		actionIncludeSearch, err := scanner.actionIncludeSearch(source, flags)
+		actionIncludeSearch, err := compactSourceActionIncludeSearch(
+			scanner,
+			source,
+			flags,
+			compactIntrinsicIncludeRoots(source),
+		)
 		if err != nil {
 			return CompactObjectVariant{}, fmt.Errorf(
 				"model source include search for %s: %w",
@@ -1607,12 +1604,6 @@ func (memo compactVariantMemo) variantForStack(
 				err,
 			)
 		}
-		intrinsicIncludeRoots := compactIntrinsicIncludeRoots(source)
-		includeDirs = appendUniqueStrings(includeDirs, intrinsicIncludeRoots...)
-		actionIncludeSearch.includeRoots = appendUniqueStrings(
-			actionIncludeSearch.includeRoots,
-			intrinsicIncludeRoots...,
-		)
 		forcedSources, err := forcedSourceInputs(flags, source, name)
 		if err != nil {
 			return CompactObjectVariant{}, fmt.Errorf(
@@ -1727,21 +1718,44 @@ func (memo compactVariantMemo) variantForStack(
 			)
 			sourceInputs = appendUniqueSourceInputs(sourceInputs, generatedClosure.sourceInputs...)
 		}
-		specialIncludeDirs := appendUniqueStrings(
-			append([]string(nil), includeDirs...),
-			specialSources.includeRoots...,
-		)
 		for _, input := range specialSources.inputs {
 			if input.path == source {
 				continue
+			}
+			specialFlags := normalizeSourceRootFlags(
+				filterResolvedKbuildFlags(object.flags, input.path),
+				opts.SourceRoot,
+			)
+			specialFlags = append(specialFlags, input.flags...)
+			specialIncludeRoots := appendUniqueStrings(
+				append([]string(nil), specialSources.includeRoots...),
+				input.includeRoots...,
+			)
+			specialIncludeRoots = appendUniqueStrings(
+				specialIncludeRoots,
+				compactIntrinsicIncludeRoots(input.path)...,
+			)
+			specialSearch, err := compactSourceActionIncludeSearch(
+				scanner,
+				input.path,
+				specialFlags,
+				specialIncludeRoots,
+			)
+			if err != nil {
+				return CompactObjectVariant{}, fmt.Errorf(
+					"model special source include search for %s of %s: %w",
+					input.path,
+					name,
+					err,
+				)
 			}
 			specialProfile := profile
 			if input.profile != sourceScanKernel {
 				specialProfile = input.profile
 			}
-			specialClosure, err := scanner.closureForSourceConfigInputsProfile(
+			specialClosure, err := scanner.closureForSourceConfigInputsSearchProfile(
 				input.path,
-				specialIncludeDirs,
+				specialSearch,
 				config,
 				isAssemblySourcePath(input.path),
 				actionFootprint.providedIncludes,
@@ -1764,10 +1778,19 @@ func (memo compactVariantMemo) variantForStack(
 			if !input.compiled {
 				continue
 			}
-			for _, forcedSource := range defaultForcedSourceInputs(input.path) {
-				forcedClosure, err := scanner.closureForSourceConfigInputsProfile(
+			specialForcedSources, err := forcedSourceInputs(specialFlags, input.path, name)
+			if err != nil {
+				return CompactObjectVariant{}, fmt.Errorf(
+					"model forced source inputs for special input %s of %s: %w",
+					input.path,
+					name,
+					err,
+				)
+			}
+			for _, forcedSource := range specialForcedSources {
+				forcedClosure, err := scanner.closureForSourceConfigInputsSearchProfile(
 					forcedSource,
-					specialIncludeDirs,
+					specialSearch,
 					config,
 					isAssemblySourcePath(input.path),
 					actionFootprint.providedIncludes,
@@ -1968,11 +1991,18 @@ func (memo compactVariantMemo) variantForStack(
 	return variant, nil
 }
 
-type compactSpecialSourceInput struct {
-	path     string
-	compiled bool
-	profile  sourceScanProfile
+// compactSourceAction describes the scanner-visible portion of a concrete
+// compile action. Special image objects and generated-header producers share
+// these descriptions so their per-source preprocessor contexts cannot drift.
+type compactSourceAction struct {
+	path         string
+	includeRoots []string
+	flags        []string
+	compiled     bool
+	profile      sourceScanProfile
 }
+
+type compactSpecialSourceInput = compactSourceAction
 
 type compactSpecialSourceInputs struct {
 	primary      string
@@ -2200,35 +2230,15 @@ func compactSpecialSourcesForObject(object string) compactSpecialSourceInputs {
 		}
 	case "arch/x86/purgatory/kexec-purgatory.o":
 		return compactSpecialSourceInputs{
-			inputs: compiled(
-				"arch/x86/purgatory/purgatory.c",
-				"arch/x86/purgatory/stack.S",
-				"arch/x86/purgatory/setup-x86_64.S",
-				"arch/x86/purgatory/entry64.S",
-				"arch/x86/boot/compressed/string.c",
-				"lib/crypto/sha256.c",
-			),
+			inputs: compactPurgatorySourceActions("x86"),
 		}
 	case "arch/riscv/purgatory/kexec-purgatory.o":
 		return compactSpecialSourceInputs{
-			inputs: compiled(
-				"arch/riscv/purgatory/purgatory.c",
-				"arch/riscv/purgatory/entry.S",
-				"lib/crypto/sha256.c",
-				"lib/string.c",
-				"lib/ctype.c",
-				"arch/riscv/lib/memcpy.S",
-				"arch/riscv/lib/memset.S",
-				"arch/riscv/lib/strcmp.S",
-				"arch/riscv/lib/strlen.S",
-				"arch/riscv/lib/strncmp.S",
-			),
+			inputs: compactPurgatorySourceActions("riscv"),
 		}
 	case "arch/powerpc/purgatory/kexec-purgatory.o":
 		return compactSpecialSourceInputs{
-			inputs: compiled(
-				"arch/powerpc/purgatory/trampoline_64.S",
-			),
+			inputs: compactPurgatorySourceActions("powerpc"),
 		}
 	case "arch/arm64/kernel/vdso32-wrap.o":
 		profile := func(path string, compiled bool) compactSpecialSourceInput {
@@ -2253,6 +2263,69 @@ func compactSpecialSourcesForObject(object string) compactSpecialSourceInputs {
 	default:
 		return compactSpecialSourceInputs{}
 	}
+}
+
+func compactPurgatorySourceActions(srcarch string) []compactSourceAction {
+	compiled := func(path string, flags ...string) compactSourceAction {
+		return compactSourceAction{
+			path:     path,
+			flags:    append([]string(nil), flags...),
+			compiled: true,
+		}
+	}
+	commonCFlags := []string{"-DDISABLE_BRANCH_PROFILING"}
+	withCommonCFlags := func(path string, flags ...string) compactSourceAction {
+		return compiled(path, append(append([]string(nil), commonCFlags...), flags...)...)
+	}
+	switch srcarch {
+	case "x86":
+		// The x86 helper adds DISABLE_BRANCH_PROFILING to every source,
+		// including assembly.
+		common := func(path string, flags ...string) compactSourceAction {
+			return withCommonCFlags(path, flags...)
+		}
+		return []compactSourceAction{
+			common("arch/x86/purgatory/purgatory.c"),
+			common("arch/x86/purgatory/stack.S"),
+			common("arch/x86/purgatory/setup-x86_64.S"),
+			common("arch/x86/purgatory/entry64.S"),
+			common("arch/x86/boot/compressed/string.c"),
+			common("lib/crypto/sha256.c", "-D__DISABLE_EXPORTS", "-D__NO_FORTIFY"),
+		}
+	case "riscv":
+		return []compactSourceAction{
+			withCommonCFlags("arch/riscv/purgatory/purgatory.c"),
+			compiled("arch/riscv/purgatory/entry.S"),
+			withCommonCFlags("lib/crypto/sha256.c", "-D__DISABLE_EXPORTS", "-D__NO_FORTIFY"),
+			withCommonCFlags("lib/string.c", "-D__DISABLE_EXPORTS"),
+			withCommonCFlags("lib/ctype.c", "-D__DISABLE_EXPORTS"),
+			compiled("arch/riscv/lib/memcpy.S"),
+			compiled("arch/riscv/lib/memset.S"),
+			compiled("arch/riscv/lib/strcmp.S"),
+			compiled("arch/riscv/lib/strlen.S"),
+			compiled("arch/riscv/lib/strncmp.S"),
+		}
+	case "powerpc":
+		return []compactSourceAction{
+			compiled("arch/powerpc/purgatory/trampoline_64.S"),
+		}
+	default:
+		return nil
+	}
+}
+
+func compactSourceActionIncludeSearch(
+	scanner *configSourceScanner,
+	source string,
+	flags []string,
+	includeRoots []string,
+) (sourceIncludeSearch, error) {
+	search, err := scanner.actionIncludeSearch(source, flags)
+	if err != nil {
+		return sourceIncludeSearch{}, err
+	}
+	search.includeRoots = appendUniqueStrings(search.includeRoots, includeRoots...)
+	return search, nil
 }
 
 func compactIntrinsicIncludeRoots(source string) []string {
@@ -2280,6 +2353,9 @@ func includeDirsFromFlags(flags []string, source string) ([]string, error) {
 		return nil, err
 	}
 	for _, flag := range pathFlags {
+		if flag.compilerProvided {
+			continue
+		}
 		if flag.option == "-include" || flag.option == "-imacros" {
 			continue
 		}
@@ -2313,6 +2389,9 @@ func forcedSourceInputs(flags []string, source, object string) ([]string, error)
 		return nil, err
 	}
 	for _, flag := range pathFlags {
+		if flag.compilerProvided {
+			continue
+		}
 		if flag.option != "-include" && flag.option != "-imacros" {
 			continue
 		}
@@ -2552,7 +2631,7 @@ func filterResolvedKbuildFlags(groups []resolvedKbuildFlag, source string) []str
 		}
 		out = append(out, group.values...)
 	}
-	return out
+	return stripCompilerBuiltinIncludeDirectoryShellFlags(out)
 }
 
 func filterResolvedKbuildFlagsForLanguage(groups []resolvedKbuildFlag, language string) []string {
@@ -2562,6 +2641,20 @@ func filterResolvedKbuildFlagsForLanguage(groups []resolvedKbuildFlag, language 
 			continue
 		}
 		out = append(out, group.values...)
+	}
+	return stripCompilerBuiltinIncludeDirectoryShellFlags(out)
+}
+
+func stripCompilerBuiltinIncludeDirectoryShellFlags(flags []string) []string {
+	out := make([]string, 0, len(flags))
+	for i := 0; i < len(flags); i++ {
+		if flags[i] == "-isystem" && i+1 < len(flags) {
+			if _, last, ok := compilerBuiltinIncludeDirectoryShell(flags, i+1); ok {
+				i = last
+				continue
+			}
+		}
+		out = append(out, flags[i])
 	}
 	return out
 }

--- a/internal/kconfig/compact_test.go
+++ b/internal/kconfig/compact_test.go
@@ -1816,6 +1816,57 @@ func TestCompactContentGraphArm64GeneratedIncludeSelectsMonolithicFamily(t *test
 	}
 }
 
+func TestCompactContentGraphArm64PKVMBindsHypConstantsFamily(t *testing.T) {
+	tree := mustParseString(t, "mainmenu \"arm64 pKVM hyp constants\"\n")
+	kb, err := ParseKbuild(strings.NewReader("obj-y += arch/arm64/kvm/pkvm.o\n"), "Kbuild")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	sourceRoot := t.TempDir()
+	mustWriteSource(t, sourceRoot, "arch/arm64/kvm/pkvm.c", "#include \"hyp_constants.h\"\n")
+	mustWriteSource(t, sourceRoot, "arch/arm64/kvm/hyp/hyp-constants.c", "int hyp_constants;\n")
+	writeCompactContentGraphForcedInputs(t, sourceRoot)
+
+	metadata, err := compactMetadataBatchWithOptionsForTest(
+		t,
+		tree,
+		kb,
+		[]NamedConfig{{Name: "arm64"}},
+		CompactMetadataOptions{
+			SourceRoot:            sourceRoot,
+			Srcarch:               "arm64",
+			CompileEnvironmentABI: "arm64-pkvm-abi-v1",
+		},
+	)
+	if err != nil {
+		t.Fatalf("CompactMetadataBatchWithOptions() failed: %v", err)
+	}
+	if len(metadata.GeneratedHeaderFamilies) != 1 ||
+		metadata.GeneratedHeaderFamilies[0].Name != compactGeneratedHeaderFamilyAll {
+		t.Fatalf("arm64 generated-header families = %#v, want monolithic all family", metadata.GeneratedHeaderFamilies)
+	}
+	family := metadata.GeneratedHeaderFamilies[0]
+	familyInputs, err := metadata.expandedSourceInputGroup(family.SourceInputGroup, "arm64 hyp constants")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sourceInputByPath(familyInputs, "arch/arm64/kvm/hyp/hyp-constants.c").Path == "" {
+		t.Fatalf("hyp-constants producer is absent from generated-header inputs: %v", familyInputs)
+	}
+	config := configByName(metadata, "arm64")
+	variant := variantByTarget(metadata, objectTarget(metadata, config, "arch/arm64/kvm/pkvm.o"))
+	var environment CompactCompileEnvironment
+	for _, candidate := range metadata.CompileEnvironments {
+		if candidate.ID == variant.CompileEnvironment {
+			environment = candidate
+			break
+		}
+	}
+	if want := []string{family.ID}; !reflect.DeepEqual(environment.GeneratedHeaderFamilies, want) {
+		t.Fatalf("pKVM generated-header families = %v, want %v", environment.GeneratedHeaderFamilies, want)
+	}
+}
+
 func TestCompactContentGraphARMGeneratedSyscallIncludeSelectsMonolithicFamily(t *testing.T) {
 	tree := mustParseString(t, `
 config AEABI
@@ -2597,6 +2648,83 @@ obj-y += arch/riscv/kernel/compat_vdso/compat_vdso.o
 	}
 }
 
+func TestCompactContentGraphX86PurgatoryUsesPerSourceActionContext(t *testing.T) {
+	tree := mustParseString(t, `
+mainmenu "x86 purgatory action context"
+
+config CRYPTO_LIB_SHA256_ARCH
+	bool "architecture SHA-256"
+`)
+	kb, err := ParseKbuild(strings.NewReader(`
+KBUILD_CFLAGS += -DCOMMON_PURGATORY_CONTEXT -include include/special-purgatory.h
+obj-y := arch/x86/purgatory/kexec-purgatory.o
+`), "Makefile")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	sourceRoot := t.TempDir()
+	for path, content := range map[string]string{
+		"arch/x86/purgatory/kexec-purgatory.S": ".incbin \"arch/x86/purgatory/purgatory.ro\"\n",
+		"arch/x86/purgatory/purgatory.c":       "int purgatory;\n",
+		"arch/x86/purgatory/stack.S":           "nop\n",
+		"arch/x86/purgatory/setup-x86_64.S":    "nop\n",
+		"arch/x86/purgatory/entry64.S":         "nop\n",
+		"arch/x86/boot/compressed/string.c":    "int string;\n",
+		"include/special-purgatory.h": `
+#ifndef COMMON_PURGATORY_CONTEXT
+#include <missing-common-purgatory-context.h>
+#endif
+`,
+		"lib/crypto/sha256.c": `
+#ifndef DISABLE_BRANCH_PROFILING
+#include <missing-purgatory-common-define.h>
+#endif
+#ifndef __NO_FORTIFY
+#include <missing-purgatory-fortify-header.h>
+#endif
+#if defined(CONFIG_CRYPTO_LIB_SHA256_ARCH) && !defined(__DISABLE_EXPORTS)
+#include "sha256.h"
+#endif
+`,
+	} {
+		mustWriteSource(t, sourceRoot, path, content)
+	}
+	writeCompactContentGraphForcedInputs(t, sourceRoot)
+	metadata, err := compactMetadataBatchWithOptionsForTest(
+		t,
+		tree,
+		kb,
+		[]NamedConfig{{
+			Name: "x86",
+			Flags: map[string]string{
+				"CONFIG_CRYPTO_LIB_SHA256_ARCH": "y",
+			},
+		}},
+		CompactMetadataOptions{
+			SourceRoot:            sourceRoot,
+			Srcarch:               "x86",
+			CompileEnvironmentABI: "x86-purgatory-abi-v1",
+		},
+	)
+	if err != nil {
+		t.Fatalf("CompactMetadataBatchWithOptions() failed: %v", err)
+	}
+	config := configByName(metadata, "x86")
+	variant := variantByTarget(metadata, objectTarget(metadata, config, "arch/x86/purgatory/kexec-purgatory.o"))
+	inputs, err := metadata.expandedSourceInputGroup(variant.SourceInputGroup, "x86 purgatory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"include/special-purgatory.h",
+		"lib/crypto/sha256.c",
+	} {
+		if sourceInputByPath(inputs, want).Path == "" {
+			t.Errorf("x86 purgatory inputs = %v, want %q", sourceInputPaths(inputs), want)
+		}
+	}
+}
+
 func TestCompactContentGraphRISCVPurgatoryBindsGeneratedImageAndProducers(t *testing.T) {
 	tree := mustParseString(t, `
 mainmenu "RISC-V purgatory image identity"
@@ -2618,14 +2746,29 @@ config KASAN_SW_TAGS
 		"arch/riscv/purgatory/kexec-purgatory.S": ".incbin \"arch/riscv/purgatory/purgatory.ro\"\n",
 		"arch/riscv/purgatory/purgatory.c":       "int purgatory;\n",
 		"arch/riscv/purgatory/entry.S":           "nop\n",
-		"lib/crypto/sha256.c":                    "int sha256;\n",
-		"lib/string.c":                           "int string;\n",
-		"lib/ctype.c":                            "int ctype;\n",
-		"arch/riscv/lib/memcpy.S":                "nop\n",
-		"arch/riscv/lib/memset.S":                "nop\n",
-		"arch/riscv/lib/strcmp.S":                "nop\n",
-		"arch/riscv/lib/strlen.S":                "nop\n",
-		"arch/riscv/lib/strncmp.S":               "nop\n",
+		"lib/crypto/sha256.c": `
+#if !defined(DISABLE_BRANCH_PROFILING) || !defined(__DISABLE_EXPORTS) || !defined(__NO_FORTIFY)
+#include <missing-riscv-sha-purgatory-context.h>
+#endif
+int sha256;
+`,
+		"lib/string.c": `
+#if !defined(DISABLE_BRANCH_PROFILING) || !defined(__DISABLE_EXPORTS)
+#include <missing-riscv-string-purgatory-context.h>
+#endif
+int string;
+`,
+		"lib/ctype.c": `
+#if !defined(DISABLE_BRANCH_PROFILING) || !defined(__DISABLE_EXPORTS)
+#include <missing-riscv-ctype-purgatory-context.h>
+#endif
+int ctype;
+`,
+		"arch/riscv/lib/memcpy.S":  "nop\n",
+		"arch/riscv/lib/memset.S":  "nop\n",
+		"arch/riscv/lib/strcmp.S":  "nop\n",
+		"arch/riscv/lib/strlen.S":  "nop\n",
+		"arch/riscv/lib/strncmp.S": "nop\n",
 	} {
 		mustWriteSource(t, sourceRoot, path, content)
 	}
@@ -4028,6 +4171,58 @@ ccflags-y += -UCONFIG_NET -DCONFIG_NET=1
 	variant := variantByTarget(metadata, target)
 	if got, want := strings.Join(variant.Flags, " "), "-UCONFIG_NET -DCONFIG_NET=1"; got != want {
 		t.Fatalf("flags = %q, want %q", got, want)
+	}
+}
+
+func TestCompactMetadataStripsCompilerBuiltinIncludeDirectoryShellFlag(t *testing.T) {
+	tree := mustParseCompactFixture(t)
+	kb, err := ParseKbuild(strings.NewReader(`
+obj-y += crypto/aegis128-neon-inner.o
+CFLAGS_crypto/aegis128-neon-inner.o += -DBEFORE -isystem $(shell $(CC) -print-file-name=include) -DAFTER
+`), "crypto/Makefile")
+	if err != nil {
+		t.Fatalf("ParseKbuild() failed: %v", err)
+	}
+	metadata, err := compactMetadataBatchForTest(t, tree, kb, []NamedConfig{{Name: "base", Flags: nil}})
+	if err != nil {
+		t.Fatalf("CompactMetadata() failed: %v", err)
+	}
+	target := objectTarget(metadata, configByName(metadata, "base"), "crypto/aegis128-neon-inner.o")
+	variant := variantByTarget(metadata, target)
+	if got, want := variant.Flags, []string{"-DBEFORE", "-DAFTER"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("flags = %q, want %q", got, want)
+	}
+	if !variant.sourceBuildReady() {
+		t.Fatalf("filtered variant is not source-build ready: %s", variant.sourceBuildError())
+	}
+}
+
+func TestCompilerBuiltinIncludeDirectoryShellFilterPreservesOtherExpressions(t *testing.T) {
+	for name, flags := range map[string][]string{
+		"arbitrary compiler query": {
+			"-isystem", "$(shell", "$(CC)", "-print-file-name=plugin)",
+		},
+		"arbitrary compiler variable": {
+			"-isystem", "$(shell", "$(HOSTCC)", "-print-file-name=include)",
+		},
+		"arbitrary make variable": {
+			"-isystem", "$(UNKNOWN_INCLUDE_DIR)",
+		},
+		"compiler query on non-system path": {
+			"-I", "$(shell", "$(CC)", "-print-file-name=include)",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			groups := []resolvedKbuildFlag{{language: "c", values: flags}}
+			got := filterResolvedKbuildFlags(groups, "crypto/aegis128-neon-inner.c")
+			if !reflect.DeepEqual(got, flags) {
+				t.Fatalf("filtered flags = %q, want unchanged %q", got, flags)
+			}
+			variant := CompactObjectVariant{Source: "crypto/aegis128-neon-inner.c", Flags: got}
+			if variant.sourceBuildReady() {
+				t.Fatalf("sourceBuildReady() accepted unsupported flags %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/kconfig/config_footprint.go
+++ b/internal/kconfig/config_footprint.go
@@ -217,6 +217,9 @@ func sourceIncludeSearchFromFlags(flags []string, source string) (sourceIncludeS
 		return sourceIncludeSearch{}, err
 	}
 	for _, flag := range pathFlags {
+		if flag.compilerProvided {
+			continue
+		}
 		if flag.option == "-include" || flag.option == "-imacros" {
 			continue
 		}
@@ -276,8 +279,9 @@ func sourceFlagPredefinedSymbols(flags []string) map[string]bool {
 }
 
 type sourcePathFlag struct {
-	option string
-	path   string
+	option           string
+	path             string
+	compilerProvided bool
 }
 
 type sourceFlagPathClass uint8
@@ -312,6 +316,18 @@ func sourcePathFlags(flags []string) ([]sourcePathFlag, error) {
 					return nil, fmt.Errorf("%s requires a path", option)
 				}
 				i++
+				if option == "-isystem" {
+					if path, last, ok := compilerBuiltinIncludeDirectoryShell(flags, i); ok {
+						result = append(result, sourcePathFlag{
+							option:           option,
+							path:             path,
+							compilerProvided: true,
+						})
+						i = last
+						matched = true
+						break
+					}
+				}
 				path := strings.TrimSpace(flags[i])
 				if path == "" {
 					return nil, fmt.Errorf("%s requires a non-empty path", option)
@@ -340,6 +356,27 @@ func sourcePathFlags(flags []string) ([]sourcePathFlag, error) {
 		}
 	}
 	return result, nil
+}
+
+const compilerBuiltinIncludeDirectoryShellExpression = "$(shell $(CC) -print-file-name=include)"
+
+// Linux uses this exact query for the compiler resource-header directory.
+// Consume it without executing a shell; every other make/shell expression
+// remains unresolved and is rejected by resolveSourceFlagPath.
+func compilerBuiltinIncludeDirectoryShell(flags []string, first int) (string, int, bool) {
+	if flags[first] == compilerBuiltinIncludeDirectoryShellExpression {
+		return compilerBuiltinIncludeDirectoryShellExpression, first, true
+	}
+	parts := []string{"$(shell", "$(CC)", "-print-file-name=include)"}
+	if first+len(parts) > len(flags) {
+		return "", first, false
+	}
+	for i, part := range parts {
+		if flags[first+i] != part {
+			return "", first, false
+		}
+	}
+	return compilerBuiltinIncludeDirectoryShellExpression, first + len(parts) - 1, true
 }
 
 func resolveSourceFlagPath(path, source string) (sourceFlagPathClass, string, error) {
@@ -1449,7 +1486,11 @@ func sourcePredefinedSymbols(srcarch string) map[string]bool {
 		"ACPI_USE_SYSTEM_CLIBRARY":  true,
 		"ACPI_USE_STANDARD_HEADERS": false,
 		"DEBUG_ZLIB":                false,
-		"MODULE":                    false,
+		// Legacy kernels gate <linux/modversions.h> with this non-CONFIG
+		// preprocessor symbol. Normal kernel compile actions do not define it;
+		// the scanner's action context still lets an explicit -D/-U override it.
+		"MODVERSIONS": false,
+		"MODULE":      false,
 	}
 	switch srcarch {
 	case "x86":
@@ -1587,7 +1628,7 @@ func generatedHeaderInclude(path string) bool {
 	}
 	switch path {
 	case "calls-eabi.S", "calls-oabi.S",
-		"kvm-asm-offsets.h", "linux/version.h", "linux/utsrelease.h":
+		"hyp_constants.h", "kvm-asm-offsets.h", "linux/version.h", "linux/utsrelease.h":
 		return true
 	default:
 		return false
@@ -1599,7 +1640,7 @@ func compilerProvidedInclude(path string) bool {
 	switch path {
 	case "float.h", "iso646.h", "limits.h", "stdalign.h", "stdarg.h",
 		"stdatomic.h", "stdbool.h", "stddef.h", "stdint.h", "stdnoreturn.h",
-		"cet.h":
+		"arm_neon.h", "cet.h":
 		return true
 	default:
 		return false

--- a/internal/kconfig/config_footprint_test.go
+++ b/internal/kconfig/config_footprint_test.go
@@ -703,6 +703,72 @@ func TestConfigSourceScannerUsesCommandLineUndefines(t *testing.T) {
 	}
 }
 
+func TestConfigSourceScannerDefaultsLegacyMODVERSIONSToUndefined(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "drivers/legacy.c", `
+#if defined(MODVERSIONS)
+#include <linux/modversions.h>
+#endif
+`)
+	scanner := newConfigSourceScanner(CompactMetadataOptions{SourceRoot: root})
+
+	if _, err := scanner.closureForSource("drivers/legacy.c", nil); err != nil {
+		t.Fatalf("default kernel scan followed inactive MODVERSIONS include: %v", err)
+	}
+	defined, err := scanner.actionIncludeSearch("drivers/legacy.c", []string{"-DMODVERSIONS"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := scanner.closureForSourceConfigInputsSearchProfile(
+		"drivers/legacy.c",
+		defined,
+		nil,
+		false,
+		nil,
+		sourceScanKernel,
+	); err == nil || !strings.Contains(err.Error(), "linux/modversions.h") {
+		t.Fatalf("explicit -DMODVERSIONS error = %v, want active missing include", err)
+	}
+	undefined, err := scanner.actionIncludeSearch("drivers/legacy.c", []string{
+		"-DMODVERSIONS",
+		"-UMODVERSIONS",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := scanner.closureForSourceConfigInputsSearchProfile(
+		"drivers/legacy.c",
+		undefined,
+		nil,
+		false,
+		nil,
+		sourceScanKernel,
+	); err != nil {
+		t.Fatalf("trailing -UMODVERSIONS did not override action define: %v", err)
+	}
+}
+
+func TestConfigSourceScannerModelsArmNeonAsCompilerProvided(t *testing.T) {
+	root := t.TempDir()
+	mustWriteSource(t, root, "arch/arm64/crypto/neon.c", "#include <arm_neon.h>\n")
+	mustWriteSource(t, root, "arch/arm64/crypto/missing.c", "#include <not-a-compiler-header.h>\n")
+	scanner := newConfigSourceScanner(CompactMetadataOptions{
+		SourceRoot: root,
+		Srcarch:    "arm64",
+	})
+	closure, err := scanner.closureForSource("arch/arm64/crypto/neon.c", nil)
+	if err != nil {
+		t.Fatalf("compiler-provided arm_neon.h was rejected: %v", err)
+	}
+	if got, want := sourceInputPaths(closure.sourceInputs), []string{"arch/arm64/crypto/neon.c"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("NEON closure inputs = %v, want %v", got, want)
+	}
+	if _, err := scanner.closureForSource("arch/arm64/crypto/missing.c", nil); err == nil ||
+		!strings.Contains(err.Error(), "not-a-compiler-header.h") {
+		t.Fatalf("arbitrary missing compiler header error = %v, want unresolved include", err)
+	}
+}
+
 func TestConfigSourceScannerContentGraphModelsTraceTemplateReinclude(t *testing.T) {
 	root := t.TempDir()
 	mustWriteSource(t, root, "drivers/trace.h", "#include <trace/define_trace.h>\n")
@@ -988,6 +1054,55 @@ func TestConfigSourceScannerContentGraphPreservesActionIncludeClassesAndOrder(t 
 		if slices.Contains(paths, shadowed) {
 			t.Errorf("action include scan selected shadowed path %q: %v", shadowed, paths)
 		}
+	}
+}
+
+func TestConfigSourceScannerModelsCompilerBuiltinIncludeDirectoryShell(t *testing.T) {
+	scanner := newConfigSourceScanner(CompactMetadataOptions{})
+	for name, flags := range map[string][]string{
+		"split kbuild tokens": {
+			"-isystem", "$(shell", "$(CC)", "-print-file-name=include)",
+			"-isystem", "$(srctree)/system",
+		},
+		"single token": {
+			"-isystem", compilerBuiltinIncludeDirectoryShellExpression,
+			"-isystem", "$(srctree)/system",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			search, err := scanner.actionIncludeSearch("crypto/aegis128-neon-inner.c", flags)
+			if err != nil {
+				t.Fatalf("actionIncludeSearch() rejected compiler builtin directory: %v", err)
+			}
+			if got, want := search.systemRoots, []string{"system"}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("system include roots = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestConfigSourceScannerRejectsOtherUnresolvedIncludeDirectoryShells(t *testing.T) {
+	scanner := newConfigSourceScanner(CompactMetadataOptions{})
+	for name, flags := range map[string][]string{
+		"arbitrary compiler query": {
+			"-isystem", "$(shell", "$(CC)", "-print-file-name=plugin)",
+		},
+		"arbitrary compiler variable": {
+			"-isystem", "$(shell", "$(HOSTCC)", "-print-file-name=include)",
+		},
+		"arbitrary make variable": {
+			"-isystem", "$(UNKNOWN_INCLUDE_DIR)",
+		},
+		"compiler query on non-system path": {
+			"-I", "$(shell", "$(CC)", "-print-file-name=include)",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := scanner.actionIncludeSearch("crypto/aegis128-neon-inner.c", flags)
+			if err == nil || !strings.Contains(err.Error(), "unresolved make variable") {
+				t.Fatalf("actionIncludeSearch() error = %v, want unresolved make variable", err)
+			}
+		})
 	}
 }
 
@@ -1522,6 +1637,11 @@ func TestGeneratedHeaderFamilyClassifierUsesOwnedSpellings(t *testing.T) {
 		},
 		{
 			path:    "calls-oabi.S",
+			name:    compactGeneratedHeaderFamilyAll,
+			precise: true,
+		},
+		{
+			path:    "hyp_constants.h",
 			name:    compactGeneratedHeaderFamilyAll,
 			precise: true,
 		},

--- a/internal/kconfig/generated_header_footprint.go
+++ b/internal/kconfig/generated_header_footprint.go
@@ -46,11 +46,7 @@ type compactGeneratedHeaderFamilyFootprint struct {
 	sourceInputs []CompactSourceInput
 }
 
-type compactGeneratedHeaderSource struct {
-	path         string
-	includeRoots []string
-	profile      sourceScanProfile
-}
+type compactGeneratedHeaderSource = compactSourceAction
 
 func generatedHeaderOffsetsSources(sources ...compactGeneratedHeaderSource) []compactGeneratedHeaderSource {
 	out := append([]compactGeneratedHeaderSource(nil), generatedHeaderOffsetsForcedSources...)
@@ -299,7 +295,28 @@ func generatedHeaderFamilyFootprint(
 		if _, ok := scanner.absForTreePath(source.path); !ok {
 			continue
 		}
-		closure, err := scanner.closureForSourceConfigProfile(source.path, source.includeRoots, config, source.profile)
+		search, err := compactSourceActionIncludeSearch(
+			scanner,
+			source.path,
+			source.flags,
+			source.includeRoots,
+		)
+		if err != nil {
+			return compactGeneratedHeaderFamilyFootprint{}, fmt.Errorf(
+				"model generated-header family %s input %s include search: %w",
+				name,
+				source.path,
+				err,
+			)
+		}
+		closure, err := scanner.closureForSourceConfigInputsSearchProfile(
+			source.path,
+			search,
+			config,
+			isAssemblySourcePath(source.path),
+			nil,
+			source.profile,
+		)
 		if err != nil {
 			return compactGeneratedHeaderFamilyFootprint{}, fmt.Errorf(
 				"scan generated-header family %s input %s: %w",
@@ -483,20 +500,7 @@ func generatedHeaderAllFootprint(
 				profile: sourceScanRISCVCompatVDSO,
 			})
 		}
-		for _, path := range []string{
-			"arch/riscv/purgatory/purgatory.c",
-			"arch/riscv/purgatory/entry.S",
-			"lib/crypto/sha256.c",
-			"lib/string.c",
-			"lib/ctype.c",
-			"arch/riscv/lib/memcpy.S",
-			"arch/riscv/lib/memset.S",
-			"arch/riscv/lib/strcmp.S",
-			"arch/riscv/lib/strlen.S",
-			"arch/riscv/lib/strncmp.S",
-		} {
-			sourcePaths = append(sourcePaths, compactGeneratedHeaderSource{path: path})
-		}
+		sourcePaths = append(sourcePaths, compactPurgatorySourceActions("riscv")...)
 	case "powerpc":
 		for _, symbol := range []string{
 			"CONFIG_PPC64",
@@ -529,10 +533,10 @@ func generatedHeaderAllFootprint(
 				})
 			}
 		}
+		// CONFIG_KEXEC_FILE is only available for PPC64, whose purgatory
+		// image is linked from trampoline_64.o and embedded by the wrapper.
+		sourcePaths = append(sourcePaths, compactPurgatorySourceActions("powerpc")...)
 		for _, source := range []compactGeneratedHeaderSource{
-			// CONFIG_KEXEC_FILE is only available for PPC64, whose purgatory
-			// image is linked from trampoline_64.o and embedded by the wrapper.
-			{path: "arch/powerpc/purgatory/trampoline_64.S"},
 			{path: "arch/powerpc/kernel/vdso/sigtramp64.S", profile: sourceScanPPC64VDSO},
 			{path: "arch/powerpc/kernel/vdso/vdso64.lds.S", profile: sourceScanPPC64VDSO},
 			{path: "arch/powerpc/kernel/vdso/sigtramp32.S", profile: sourceScanPPC32VDSO},
@@ -546,7 +550,27 @@ func generatedHeaderAllFootprint(
 		if _, ok := scanner.absForTreePath(source.path); !ok {
 			continue
 		}
-		closure, err := scanner.closureForSourceConfigProfile(source.path, source.includeRoots, config, source.profile)
+		search, err := compactSourceActionIncludeSearch(
+			scanner,
+			source.path,
+			source.flags,
+			source.includeRoots,
+		)
+		if err != nil {
+			return compactGeneratedHeaderFamilyFootprint{}, fmt.Errorf(
+				"model generated-header all-family input %s include search: %w",
+				source.path,
+				err,
+			)
+		}
+		closure, err := scanner.closureForSourceConfigInputsSearchProfile(
+			source.path,
+			search,
+			config,
+			isAssemblySourcePath(source.path),
+			nil,
+			source.profile,
+		)
 		if err != nil {
 			return compactGeneratedHeaderFamilyFootprint{}, fmt.Errorf(
 				"scan generated-header all-family input %s: %w",
@@ -686,7 +710,7 @@ func generatedHeaderFamilyNameForInclude(path string) (string, bool) {
 		return compactGeneratedHeaderFamilyRQOffsets, true
 	case "kvm-asm-offsets.h", "generated/kvm-asm-offsets.h":
 		return compactGeneratedHeaderFamilyKVMOffsets, true
-	case "calls-eabi.S", "calls-oabi.S":
+	case "calls-eabi.S", "calls-oabi.S", "hyp_constants.h":
 		return compactGeneratedHeaderFamilyAll, true
 	}
 	if strings.HasPrefix(path, "asm/") || strings.HasPrefix(path, "uapi/asm/") {


### PR DESCRIPTION
## Summary

- model legacy `MODVERSIONS` as undefined unless the action explicitly defines it
- scan x86 and RISC-V purgatory sources with their real per-source preprocessor context
- bind ARM64 KVM `hyp_constants.h` to the generated-header family used by every consumer
- accept compiler-provided `arm_neon.h` while preserving fail-closed behavior for arbitrary missing headers
- recognize and remove only Kbuild's exact Clang builtin-header query, `-isystem $(shell $(CC) -print-file-name=include)`, before graph/action emission

## Why

The compact scanner used an incomplete approximation of several real compile contexts. Valid Linux 6.18 configurations could therefore fail during repository graph generation before Bazel reached compilation.

Closes #68.
Closes #69.
Closes #72.
Closes #73.

## Validation

- `go test ./internal/kconfig ./internal/cmd/kconfig ./internal/cmd/kconfig_parse ./internal/cmd/compact_metadata_check ./internal/rusttoolchain -count=1`
- all 150 internal Bazel tests passed under their intended configurations on the integration branch
- locally packaged the Linux amd64 Kconfig tools and used them to generate the ARM64 KVM graph through actual object compilation
